### PR TITLE
fix: shows empty div even though display disabled from settings

### DIFF
--- a/includes/modules/stock-countdown/templates/simple-stock-status.php
+++ b/includes/modules/stock-countdown/templates/simple-stock-status.php
@@ -18,6 +18,14 @@ $shop_bar_enable          = sgsb_find_option_setting( $settings, 'shop_page_prog
 $shop_countdown_enable    = sgsb_find_option_setting( $settings, 'shop_page_countdown_enable', true );
 $product_bar_enable       = sgsb_find_option_setting( $settings, 'product_page_progress_bar_enable', true );
 $product_countdown_enable = sgsb_find_option_setting( $settings, 'product_page_countdown_enable', true );
+
+$hide_template_in_shop    = is_shop() && ( ! $product->managing_stock() || ! $shop_bar_enable ) && ! $shop_countdown_enable;
+$hide_template_in_product = is_product() && ( ! $product->managing_stock() || ! $product_bar_enable ) && ! $product_countdown_enable;
+
+if ( $hide_template_in_shop || $hide_template_in_product ) {
+	return false;
+}
+
 ?>
 <div class="sgsb-stock-counter-and-bar">
 	<?php


### PR DESCRIPTION
* Checked if both bar & countdown are disabled or not. if both disabled then returned false therefore the template doesn't get loaded.

Resolves #19