### PR TITLE
fix: offer amount was assigned into wrong variable when type isn't discount

### DIFF
--- a/includes/modules/upsell-order-bump/includes/class-order-bump.php
+++ b/includes/modules/upsell-order-bump/includes/class-order-bump.php
@@ -71,7 +71,7 @@ class Order_Bump {
 			if ( 'discount' === $offer_type ) {
 				$offer_price = ceil( intval( $regular_price ) - intval( $regular_price * $offer_amount ) / 100 );
 			} else {
-				$regular_price = $offer_amount;
+				$offer_price = $offer_amount;
 			}
 
 			if (


### PR DESCRIPTION
Resolves #28