### PR TITLE
fix: order bump offer showing even though the offer product added to the cart from other places (i.e. shop page)

### DIFF
--- a/includes/modules/upsell-order-bump/includes/class-order-bump.php
+++ b/includes/modules/upsell-order-bump/includes/class-order-bump.php
@@ -58,8 +58,6 @@ class Order_Bump {
 			$offer_product_id = $bump_info->offer_product;
 			$offer_type       = $bump_info->offer_type;
 			$offer_amount     = $bump_info->offer_amount;
-			$product_cart_id  = WC()->cart->generate_cart_id( $offer_product_id );
-			$in_cart          = WC()->cart->find_product_in_cart( $product_cart_id );
 
 			$checked = '';
 			if ( in_array( (int) $offer_product_id, $all_cart_product_ids, true ) ) {
@@ -74,6 +72,24 @@ class Order_Bump {
 				$regular_price = $offer_amount;
 			}
 
+			$cart                            = WC()->cart;
+			$product_already_added_from_shop = false;
+			foreach ( $cart->get_cart() as $cart_item_key => $cart_item ) {
+				$product    = $cart_item['data'];
+				$product_id = $product->get_id();
+				if ( absint( $product_id ) !== absint( $offer_product_id ) ) {
+					continue;
+				}
+				$price = $product->get_price();
+				if ( floatval( $price ) !== floatval( $offer_price ) ) {
+					$product_already_added_from_shop = true;
+				}
+				break;
+			}
+			if ( $product_already_added_from_shop ) {
+				// don't show the offer if the 'offer product' is already added in the cart from the shop page with regular price.
+				continue;
+			}
 			if (
 				$bump_info->target_products
 				&&


### PR DESCRIPTION
* removed unnecessary codes in line 61,62
* checked if the 'order bump offer product' already added in the cart from places other that the 'order bump offer card'. This check was done by checking if the 'offer product price in the cart' is the same as the 'calculated offer price'. if they're not same then the product in the cart identified as added from places other than 'the bump offer bar' (i.e. from the shop page). And this way if the offer product is identified to be added to the cart from other places then, made sure the 'order bump offer bar' doesn't show in the checkout page as the product already added to the card with a diferent price (i.e. regular price).

Resolves #24