### PR TITLE
fix: php notice ('category_ids was called incorrectly') showing in checkout page

### DIFF
--- a/includes/modules/upsell-order-bump/includes/class-ajax.php
+++ b/includes/modules/upsell-order-bump/includes/class-ajax.php
@@ -112,7 +112,8 @@ class Ajax {
 		$all_cart_products = $woocommerce->cart->get_cart();
 
 		foreach ( $all_cart_products as $value ) {
-			foreach ( $value['data']->category_ids as $cat_id ) {
+			$cat_ids = $value['data']->get_category_ids();
+			foreach ( $cat_ids as $cat_id ) {
 				$all_cart_category_ids[] = $cat_id;
 			}
 			$all_cart_product_ids[] = $value['product_id'];

--- a/includes/modules/upsell-order-bump/includes/class-order-bump.php
+++ b/includes/modules/upsell-order-bump/includes/class-order-bump.php
@@ -46,7 +46,8 @@ class Order_Bump {
 		$showed_bump_product_id = array();
 
 		foreach ( $all_cart_products as $value ) {
-			foreach ( $value['data']->category_ids as $cat_id ) {
+			$cat_ids = $value['data']->get_category_ids();
+			foreach ( $cat_ids as $cat_id ) {
 				$all_cart_category_ids[] = $cat_id;
 			}
 			$all_cart_product_ids[] = $value['product_id'];


### PR DESCRIPTION
refactored: used 'get_category_ids' method instead of directly accessing the 'category_ids' property.

Resolves #44