### PR TITLE
fix: filtered out 'External/Affiliate' products from products_list

### DIFF
--- a/includes/modules/upsell-order-bump/includes/class-enqueue-script.php
+++ b/includes/modules/upsell-order-bump/includes/class-enqueue-script.php
@@ -148,6 +148,14 @@ class Enqueue_Script {
 		$args = array(
 			'post_type'      => 'product',
 			'posts_per_page' => -1,
+			'tax_query'      => array(
+				array(
+					'taxonomy' => 'product_type',
+					'field'    => 'slug',
+					'terms'    => 'external',
+					'operator' => 'NOT IN',
+				),
+			),
 		);
 
 		$products = get_posts( $args );


### PR DESCRIPTION
* Did this because 'External/Affiliate' products shouldn't be in the oder bumps' target products' list or offer product's list

Resolves #63