### PR TITLE
fix: when same 'offer product' with different 'offer price' needs to be shown, made sure the best offer among them is shown

### DIFF
--- a/includes/modules/upsell-order-bump/includes/class-order-bump.php
+++ b/includes/modules/upsell-order-bump/includes/class-order-bump.php
@@ -92,7 +92,7 @@ class Order_Bump {
 				continue;
 			}
 			if (
-				$bump_info->target_products
+				isset( $bump_info->target_products )
 				&&
 				count( $all_cart_product_ids ) !== count( array_diff( $all_cart_product_ids, $bump_info->target_products ) )
 				&&


### PR DESCRIPTION
when there's multiple bumps for same products with different 'offer price' and they all are eligible to be shown in the checkout page, made sure the one with be 'best offer' (cheapest price) show's for the bump.

Before this fix, in the described scenario the bump that was created last, was showing in the checkout page for that 'offer product' regardless of their 'offer price', which shouldn't be the case.

For more clarity, take 2 bumps for example, where both of the bumps is for a product `smartphone`. One of the bump is like: if you buy a `laptop` you'll get `30% discount` on the `smartphone`. And the other one is, if you buy a `macbook` you'll get `50% discount` on that same `smartphone`.
Now, if a customer adds both `laptop` & `macbook` to their cart which one of 'those 2 discounts for the smartphone' should be shown? 
should he see the '30%' or should he see the '50%' discount? 
Clearly he should get the 'best' among those 2 which is '50%'. 

And that's basically what was done in this commit. Before this fix it used to show the 'offer price' from the bump that was created last.

Resolves https://github.com/Invizo/storegrowth-sales-booster/issues/47