### PR TITLE
fix: 'order now' button in flycart sidebar checkout page not being clickable when 'ship to differet addresses' button is toggled

### DIFF
--- a/includes/modules/fly-cart/assets/js/wfc-script.js
+++ b/includes/modules/fly-cart/assets/js/wfc-script.js
@@ -168,16 +168,7 @@
 
       let checkoutFrame = document.createElement('iframe');
       checkoutFrame.classList.add('sgsb-fast-cart-checkout-frame');
-      checkoutFrame.setAttribute('scrolling', 'no');
-
-      window.sgsbFastCart = {
-        updateIframeHeight: function (iframeHeight) {
-          checkoutFrame.style.height = ( iframeHeight ) + 'px';
-          if ( checkoutFrame.isAttached ) {
-              checkoutFrame.style.opacity = 1;
-          }
-        }
-      };
+      checkoutFrame.style.height = '100vh';
 
       let url = new URL(href);
       url.searchParams.set('sgsb-checkout', 'true');

--- a/includes/modules/fly-cart/templates/fast-checkout.php
+++ b/includes/modules/fly-cart/templates/fast-checkout.php
@@ -33,12 +33,5 @@
 	?>
 
 	<?php wp_footer(); ?>
-	<script>
-		jQuery(window).load(function() {
-			if ( window.parent.sgsbFastCart ) {
-				window.parent.sgsbFastCart.updateIframeHeight( jQuery( 'html' ).height() );
-			}
-		});
-	</script>
 </body>
 </html>


### PR DESCRIPTION
removed some unnecessary js code where the iframe was being created and also removed the 'unnecessary' overenginnered js scripts from 'fast-checkout.php' file.

(Resolves the main part of the issue 87)

Resolves #87