### PR TITLE
fix: initial banner data set only for the very first time of the plugin's lifetime

### DIFF
--- a/includes/modules/progressive-discount-banner/class-progressive-discount-banner-module.php
+++ b/includes/modules/progressive-discount-banner/class-progressive-discount-banner-module.php
@@ -86,11 +86,35 @@ class Progressive_Discount_Banner_Module implements Module_Skeleton {
 	}
 
 	/**
+	 * Setting Initial Banner Data.
+	 *
+	 * @return void
+	 */
+	public function set_initial_banner_data() {
+		$flags = get_option( 'sgsb_discount_banner_flags', array() );
+		if ( isset( $flags['done_setting_initial_banner_data'] ) ) {
+			return;
+		}
+		$default_data = array(
+			'default_banner_text'     => 'Shop more than $100 to get free shipping.',
+			'progressive_banner_text' => 'Add more [amount] to get free shipping.',
+			'goal_completion_text'    => 'You have successfully acquired free shipping.',
+		);
+		delete_option( 'sgsb_progressive_discount_banner_settings' );
+		$result = update_option( 'sgsb_progressive_discount_banner_settings', $default_data );
+		elog( array( 'result' => $result ) );
+		if ( $result ) {
+			update_option( 'sgsb_discount_banner_flags', array( 'done_setting_initial_banner_data' => true ) );
+		}
+	}
+
+	/**
 	 * Starting point of the module.
 	 *
 	 * @return void
 	 */
 	public function init() {
+		$this->set_initial_banner_data();
 		require_once __DIR__ . '/includes/functions.php';
 		require_once __DIR__ . '/includes/class-ajax.php';
 		require_once __DIR__ . '/includes/class-common-hooks.php';

--- a/includes/modules/progressive-discount-banner/class-progressive-discount-banner-module.php
+++ b/includes/modules/progressive-discount-banner/class-progressive-discount-banner-module.php
@@ -102,7 +102,6 @@ class Progressive_Discount_Banner_Module implements Module_Skeleton {
 		);
 		delete_option( 'sgsb_progressive_discount_banner_settings' );
 		$result = update_option( 'sgsb_progressive_discount_banner_settings', $default_data );
-		elog( array( 'result' => $result ) );
 		if ( $result ) {
 			update_option( 'sgsb_discount_banner_flags', array( 'done_setting_initial_banner_data' => true ) );
 		}


### PR DESCRIPTION
Resolves #88