### PR TITLE
fix: menu icon not loading for typo issue in linux (and simillar os)

### DIFF
--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -38,7 +38,7 @@ class Admin_Menu {
 			'manage_options',
 			'sales-booster-for-woocommerce',
 			array( $this, 'modules_callback' ),
-			STOREGROWTH_PLUGIN_DIR_URL . 'assets/images/StoreGrowth.svg',
+			STOREGROWTH_PLUGIN_DIR_URL . 'assets/images/storegrowth.svg',
 			58
 		);
 


### PR DESCRIPTION
Resolves #126