### PR TITLE
fix(fs-bar): bar tansiton fix and padding top

### DIFF
--- a/includes/modules/floating-notification-bar/assets/css/floating-notification-bar.css
+++ b/includes/modules/floating-notification-bar/assets/css/floating-notification-bar.css
@@ -113,7 +113,7 @@ body {
 .body-padding-transition {
     padding-top: 20px;
     /* Adjust the padding value as needed */
-    transition: padding-top 0.5s ease;
+    transition: padding-top 0.5s linear;
     /* Adjust the transition duration and timing function as needed */
 }
 

--- a/includes/modules/floating-notification-bar/assets/js/sgsb-pd-banner-bar-remove.js
+++ b/includes/modules/floating-notification-bar/assets/js/sgsb-pd-banner-bar-remove.js
@@ -44,9 +44,8 @@
     };
 
     const bannerShow = () => {
-      $(".sgsb-floating-notification-bar-wrapper").fadeIn(1000, function () {
-        paddingAdderBody();
-      });
+      $(".sgsb-floating-notification-bar-wrapper").fadeIn(1000);
+      paddingAdderBody();
     };
 
     const bannerHide = () => {

--- a/includes/modules/progressive-discount-banner/assets/css/progressive-discount-banner.css
+++ b/includes/modules/progressive-discount-banner/assets/css/progressive-discount-banner.css
@@ -79,3 +79,9 @@ body.admin-bar .sgsb-pd-banner-bar-wrapper {
 body {
     padding-top: 70px;
 }
+
+.body-padding-transition {
+  padding-top: 20px;
+  transition: padding-top 0.5s linear;
+}
+

--- a/includes/modules/progressive-discount-banner/assets/js/sgsb-pd-banner-bar-remove.js
+++ b/includes/modules/progressive-discount-banner/assets/js/sgsb-pd-banner-bar-remove.js
@@ -3,6 +3,7 @@
 
   if (typeof sgsb_fsb_data !== "undefined") {
     let banner_device_view = sgsb_fsb_data.banner_device_view;
+    let bar_position = sgsb_fsb_data.bar_position;
     let banner_delay = sgsb_fsb_data.banner_delay;
     let scroll_banner_delay = sgsb_fsb_data.scroll_banner_delay;
     let banner_trigger = sgsb_fsb_data.banner_trigger;
@@ -27,12 +28,17 @@
 
     // Add the padding
     const paddingAdderBody = () => {
-      return (document.body.style.paddingTop = `${body_top_padding}px`);
+      document.body.classList.add("body-padding-transition");
+      if("top" ===bar_position){
+        return (document.body.style.paddingTop = `${body_top_padding}px`);
+      }else{
+        return (document.body.style.paddingBottom = `${body_top_padding}px`);
+      }
     };
 
     const bannerShow = () => {
-      paddingAdderBody();
       $(".sgsb-pd-banner-bar-wrapper").fadeIn(1000);
+      paddingAdderBody();
     };
 
     const bannerHide = () => {


### PR DESCRIPTION
In this commit when the bar is set to bottom the padding top that is being added is removed. and transition also fixed
before fix:
![image](https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/cd36a74c-60ef-40d6-8a8a-16bae97b4744)

after fix:
<img width="1023" alt="image" src="https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/20f1c0da-ee01-4362-9aea-9d9d89718951">

resolves: #259