### PR TITLE
fix(order-bump): offer product data

### DIFF
--- a/includes/modules/upsell-order-bump/assets/src/components/BasicInfo.js
+++ b/includes/modules/upsell-order-bump/assets/src/components/BasicInfo.js
@@ -38,7 +38,7 @@ const BasicInfo = ( { clearErrors } ) => {
     }
   };
 
-  const offerProductId = createBumpData?.offer_product;
+  const offerProductId = parseInt(createBumpData?.offer_product);
   const originalProductListForSelect = products_and_categories.product_list.productListForSelect;
   const productListForSelect = offerProductId ? originalProductListForSelect.filter(item => item.value !== offerProductId) : originalProductListForSelect;
 
@@ -46,7 +46,6 @@ const BasicInfo = ( { clearErrors } ) => {
   const originalSimpleProductForOffer = products_and_categories.product_list.simpleProductForOffer;
   const simpleProductForOffer = Array.isArray(targetProducts) && targetProducts.length !== 0 ?
     originalSimpleProductForOffer.filter(item => !targetProducts.includes(item.value) ) : originalSimpleProductForOffer;
-
   const bumpSchedules = [
     { value: 'daily', label: __( 'Daily', 'storegrowth-sales-booster' ) },
     { value: 'saturday', label: __( 'Saturday', 'storegrowth-sales-booster' ) },
@@ -62,6 +61,11 @@ const BasicInfo = ( { clearErrors } ) => {
     { value: 'discount', label: __( 'Discount%', 'storegrowth-sales-booster' ) },
     { value: 'price', label: __( 'Price', 'storegrowth-sales-booster' ) },
   ];
+
+  function filterByValue(data, key) {
+    const item = data.find(item => item.value === key);
+    return item ? item.label : 'Value not found';
+}
 
   return (
     <Fragment>
@@ -109,9 +113,9 @@ const BasicInfo = ( { clearErrors } ) => {
           changeHandler={ onFieldChange }
           options={ simpleProductForOffer }
           classes={ `search-single-select` }
-          title={ __( 'Offer Product Title', 'storegrowth-sales-booster' ) }
+          title={ __( 'Offer Product', 'storegrowth-sales-booster' ) }
           placeHolderText={ __( 'Search for offer product', 'storegrowth-sales-booster' ) }
-          fieldValue={ parseInt( createBumpData.offer_product ) ? parseInt( createBumpData.offer_product ) : null }
+          fieldValue={ offerProductId ? filterByValue(simpleProductForOffer,offerProductId) : null }
           filterOption={ ( inputValue, option ) => option.label
             ?.toString()
             ?.toLowerCase()


### PR DESCRIPTION
In this commit the offer product data is being fixed before the fix it was giving the product id after the fix the product titlte is being visible.

<img width="1252" alt="image" src="https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/f0ce64eb-0d32-40d4-a5c7-77d4648df289">


resolves: #271