### PR TITLE
fix(fn-bar): show cupon default state

### DIFF
--- a/includes/modules/floating-notification-bar/assets/src/components/BannerTrigger.js
+++ b/includes/modules/floating-notification-bar/assets/src/components/BannerTrigger.js
@@ -56,7 +56,7 @@ const BannerTrigger = (props) => {
                 min={0}
                 disabled={upgradeTeaser}
                 style={{
-                  width: "20%",
+                  width: "40px",
                   borderColor: "#DDE6F9",
                 }}
                 name={

--- a/includes/modules/floating-notification-bar/assets/src/components/FloatingNotificationBarLayout.js
+++ b/includes/modules/floating-notification-bar/assets/src/components/FloatingNotificationBarLayout.js
@@ -36,7 +36,7 @@ function FloatingNotificationBarLayout({
     cupon_code                 : '',
     text_color                 : '#ffffff',
     icon_color                 : '#ffffff',
-    show_cupon                 : true,
+    show_cupon                 : false,
     button_view                : ['button-desktop-enable'],
     font_family                : 'poppins',
     banner_delay               : 7,


### PR DESCRIPTION
In this fix the default state is set to false for the show coupon code

resolves: #277 