### PR TITLE
feat(fs-bar): bar position is set to pro

### DIFF
--- a/includes/modules/progressive-discount-banner/assets/src/components/DiscountBanner.js
+++ b/includes/modules/progressive-discount-banner/assets/src/components/DiscountBanner.js
@@ -116,7 +116,8 @@ function DiscountBanner(props) {
                     name={`bar_position`}
                     options={[...barPositions]}
                     fieldValue={formData.bar_position}
-                    changeHandler={onFieldChange}
+                    changeHandler={upgradeTeaser?noop:onFieldChange}
+                    needUpgrade={upgradeTeaser}
                     title={__("Bar Position", "storegrowth-sales-booster")}
                 />
                 <SelectBox


### PR DESCRIPTION
In this commit the bar position for the free shipping bar is set to pro version

<img width="519" alt="image" src="https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/3e8906bf-9d49-4f23-bc1c-e10df8bed411">


resolves: #281