### PR TITLE
feat(admin-ui): module activation message alert

### DIFF
--- a/assets/src/admin.scss
+++ b/assets/src/admin.scss
@@ -274,7 +274,7 @@ Pagination Style
 .sgsb-search-section {
 
   .search-bar {
-    
+
     padding-right: 10px;
 
     @media (max-width: 520px) {
@@ -294,13 +294,13 @@ Pagination Style
 
         }
 
-        .ant-input-group-wrapper{
-          span{
-            &.ant-input-wrapper{
+        .ant-input-group-wrapper {
+          span {
+            &.ant-input-wrapper {
               display: flex;
             }
           }
-          
+
         }
 
       }
@@ -312,10 +312,10 @@ Pagination Style
 
       }
 
-  
+
     }
 
-    
+
   }
 
   input[class] {
@@ -2021,6 +2021,7 @@ End Settings Sidebar
               }
             }
           }
+
           .single-disabled-checkbox {
             position: relative;
 
@@ -2307,7 +2308,7 @@ End Settings Sidebar
                 }
 
                 &.custom-field {
-                  label.ant-radio-button-wrapper{
+                  label.ant-radio-button-wrapper {
                     &:hover {
                       border-color: #DDE6F9;
                       background: transparent;
@@ -2746,3 +2747,16 @@ End Settings Sidebar
   background-repeat: no-repeat;
 }
 
+// Modal styles
+.modal-content-wrapper {
+  text-align: center;
+  padding: 5px;
+
+  h3 {
+    &.modal-content-heading {
+      font-size: 20px;
+      font-weight: 700;
+      color: #102F50;
+    }
+  }
+}

--- a/assets/src/components/modules/ActivationAlert.js
+++ b/assets/src/components/modules/ActivationAlert.js
@@ -1,0 +1,54 @@
+import React from "react";
+import { Button, Modal } from "antd";
+import { ExclamationCircleFilled } from "@ant-design/icons";
+const ActivationAlert = ({
+  activeModule,
+  activeModalData,
+  modalButtonLoad,
+  handleModalAlert,
+  handleModuleActivation
+}) => {
+  return (
+    <div>
+      <Modal
+        centered={true}
+        open={activeModule}
+        onCancel={handleModalAlert}
+        footer={[
+          <Button
+            loading={modalButtonLoad}
+            key="submit"
+            style={{
+              color: "green",
+              border: "1px solid green",
+            }}
+            onClick={() => handleModuleActivation(activeModalData)}
+          >
+            Yes
+          </Button>,
+          <Button key="back" danger onClick={handleModalAlert}>
+            Cancel
+          </Button>,
+        ]}
+      >
+        <div className="modal-content-wrapper">
+          <h3 className="modal-content-heading">
+            <ExclamationCircleFilled
+              style={{
+                color: "orange",
+              }}
+            />{" "}
+            {`Do you want to active ${activeModalData?.name}?`}
+          </h3>
+          <p className="modal-content">
+            After activating the <strong>{activeModalData?.name}</strong>{" "}
+            module, you will be redirected to the module settings page where you
+            can set up this module's features..
+          </p>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default ActivationAlert;


### PR DESCRIPTION
**Description**
In this commit if the module is by default deactivated or inactive it will pop up an alert that will show to activate the module and redirect to its designamted settings page.

<img width="1269" alt="image" src="https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/33d419c2-19ab-402b-a9ff-0a404fa29fb2">



resolves: #283