### PR TITLE
fix(sales-countdown): font and renamed

### DIFF
--- a/includes/modules/countdown-timer/assets/src/components/Preview.js
+++ b/includes/modules/countdown-timer/assets/src/components/Preview.js
@@ -254,7 +254,7 @@ const Preview = ( { formData } ) => {
                                     fontSize      : 12,
                                     textAlign     : 'center',
                                     paddingTop    : 12,
-                                    fontFamily    : 'Inter',
+                                    
                                     borderRadius  : 8,
                                     letterSpacing : 2,
                                     textTransform : 'uppercase',
@@ -288,7 +288,7 @@ const Preview = ( { formData } ) => {
                                     height        : 64,
                                     fontSize      : 12,
                                     textAlign     : 'center',
-                                    fontFamily    : 'Inter',
+                                    
                                     paddingTop    : 12,
                                     borderRadius  : 8,
                                     letterSpacing : 2,
@@ -323,7 +323,7 @@ const Preview = ( { formData } ) => {
                                     height        : 64,
                                     fontSize      : 12,
                                     textAlign     : 'center',
-                                    fontFamily    : 'Inter',
+                                    
                                     paddingTop    : 12,
                                     borderRadius  : 8,
                                     letterSpacing : 2,
@@ -358,7 +358,7 @@ const Preview = ( { formData } ) => {
                                     height        : 64,
                                     fontSize      : 12,
                                     textAlign     : 'center',
-                                    fontFamily    : 'Inter',
+                                    
                                     paddingTop    : 12,
                                     borderRadius  : 8,
                                     letterSpacing : 2,

--- a/includes/modules/countdown-timer/assets/src/components/Templates/CountDownTwo.js
+++ b/includes/modules/countdown-timer/assets/src/components/Templates/CountDownTwo.js
@@ -60,7 +60,6 @@ const CountDownTwo = () => {
                             padding       : '14px 0',
                             fontSize      : 12,
                             textAlign     : 'center',
-                            fontFamily    : 'Inter',
                             borderRadius  : 8,
                             letterSpacing : 2,
                             textTransform : 'uppercase',
@@ -94,7 +93,7 @@ const CountDownTwo = () => {
                             padding       : '14px 0',
                             fontSize      : 12,
                             textAlign     : 'center',
-                            fontFamily    : 'Inter',
+                            
                             borderRadius  : 8,
                             letterSpacing : 2,
                             textTransform : 'uppercase',
@@ -128,7 +127,7 @@ const CountDownTwo = () => {
                             padding       : '14px 0',
                             fontSize      : 12,
                             textAlign     : 'center',
-                            fontFamily    : 'Inter',
+                            
                             borderRadius  : 8,
                             letterSpacing : 2,
                             textTransform : 'uppercase',
@@ -162,7 +161,7 @@ const CountDownTwo = () => {
                             padding       : '14px 0',
                             fontSize      : 12,
                             textAlign     : 'center',
-                            fontFamily    : 'Inter',
+                            
                             borderRadius  : 8,
                             letterSpacing : 2,
                             textTransform : 'uppercase',

--- a/includes/modules/countdown-timer/includes/class-common-hooks.php
+++ b/includes/modules/countdown-timer/includes/class-common-hooks.php
@@ -57,7 +57,7 @@ class Common_Hooks {
 		if ( ! $this->is_external_product() ) {
 			// Adds the new tab.
 			$tabs['countdown_timer_tab'] = array(
-				'label'  => __( 'Countdown Timer', 'storegrowth-sales-booster' ),
+				'label'  => __( 'Sales Countdown', 'storegrowth-sales-booster' ),
 				'target' => 'sgsb-countdown-timer-tab',
 			);
 		}


### PR DESCRIPTION
The font mismatched in the admin ui is for the preview panel is fixed
<img width="1013" alt="image" src="https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/18f33c94-1526-4572-aa13-536f3b1550de">



The name mismatched in the woocommerce meta is renamed
<img width="881" alt="image" src="https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/12041cad-579e-49ff-9b5f-677a2486c9ff">

- [x] Preview timer font mismatch [link](https://www.evernote.com/shard/s744/sh/dab57db3-04bc-4940-bc0b-f689be5c58a9/lZw8l7kW3zqtrYb5rFVkVyxeKiwEQvBKcENxzBeEMNx5lcn7CgwQHzf41w)
- [x] Countdown Timer Rename it to Sales Countdown in the products setting meta
 
- [x] Countdown Timer is not working from the current Date
`(As example current date is 24/10/23 the countdown calculation suppose to start from 24/10/23 but the calculation is starting from 23/10/23)` ❌❌

resolves: #288