### PR TITLE
fix(direct-checkout): satate issue and Quick cart redirect disable

### DIFF
--- a/assets/src/components/settings/Panels/PanelSettings/Fields/SelectBox.js
+++ b/assets/src/components/settings/Panels/PanelSettings/Fields/SelectBox.js
@@ -48,10 +48,10 @@ const SelectBox = ( {
                     style={{ width: fieldWidth ? fieldWidth : ( colSpan === 24 ? 170 : 70 ) }}
                 >
                     { options && options.map( option => (
-                        <Select.Option key={ option?.value }>
+                        <Select.Option key={ option?.value } disabled={option?.disabled}>
                             { option?.label }
-                            { option?.disabled && <UpgradeCrown /> }
-                            { option?.disabled && <UpgradeOverlay /> }
+                            { option?.needUpgrade && <UpgradeCrown /> }
+                            { option?.needUpgrade && <UpgradeOverlay /> }
                         </Select.Option>
                     ) ) }
                 </Select>

--- a/includes/modules/direct-checkout/assets/js/sgsb-dc-script.js
+++ b/includes/modules/direct-checkout/assets/js/sgsb-dc-script.js
@@ -20,7 +20,7 @@
       productId = typeof productId === 'undefined' ? $( event?.target ).data( 'product_id' ) : productId;
 
       jQuery.ajax({
-        url     : wc_add_to_cart_params.ajax_url,
+        url     : sgsbDcFrontend?.ajax_url,
         type    : 'POST',
         data    : {
           'action'     : 'woocommerce_add_to_cart',

--- a/includes/modules/direct-checkout/assets/src/components/General.js
+++ b/includes/modules/direct-checkout/assets/src/components/General.js
@@ -18,9 +18,7 @@ function General({ onFormSave, upgradeTeaser }) {
       getButtonLoading: select("sgsb_direct_checkout").getButtonLoading(),
     })
   );
-  const isQuickCartActive = sgsbAdminQuickCartValidate.isQuickCartActivated
-    ? false
-    : true;
+  const isQuickCartActive = sgsbAdminQuickCartValidate.isQuickCartActivated;
   const onFieldChange = (key, value) => {
     setCreateFromData({
       ...createDirectCheckoutFormData,
@@ -74,7 +72,7 @@ function General({ onFormSave, upgradeTeaser }) {
     {
       value: "quick-cart-checkout",
       label: __("Quick Cart Checkout", "storegrowth-sales-booster"),
-      needUpgrade:upgradeTeaser,
+      needUpgrade: upgradeTeaser,
       disabled: isQuickCartActive,
     },
   ];

--- a/includes/modules/direct-checkout/assets/src/components/General.js
+++ b/includes/modules/direct-checkout/assets/src/components/General.js
@@ -6,7 +6,7 @@ import SingleCheckBox from "../../../../../../assets/src/components/settings/Pan
 import SelectBox from "../../../../../../assets/src/components/settings/Panels/PanelSettings/Fields/SelectBox";
 import SettingsSection from "../../../../../../assets/src/components/settings/Panels/PanelSettings/SettingsSection";
 import ActionsHandler from "sales-booster/src/components/settings/Panels/PanelSettings/ActionsHandler";
-import {createDirectCheckoutForm} from "../helper"
+import { createDirectCheckoutForm } from "../helper";
 
 function General({ onFormSave, upgradeTeaser }) {
   const { setCreateFromData } = useDispatch("sgsb_direct_checkout");
@@ -18,10 +18,12 @@ function General({ onFormSave, upgradeTeaser }) {
       getButtonLoading: select("sgsb_direct_checkout").getButtonLoading(),
     })
   );
-
+  const isQuickCartActive = sgsbAdminQuickCartValidate.isQuickCartActivated
+    ? false
+    : true;
   const onFieldChange = (key, value) => {
     setCreateFromData({
-      ...createDirectCheckoutForm,
+      ...createDirectCheckoutFormData,
       [key]: value,
     });
   };
@@ -29,7 +31,7 @@ function General({ onFormSave, upgradeTeaser }) {
   const onFormReset = () => {
     setCreateFromData({ ...createDirectCheckoutForm });
   };
-  
+
   const noop = () => {};
 
   const checkboxesOption = [
@@ -65,8 +67,16 @@ function General({ onFormSave, upgradeTeaser }) {
 
   // Define select options
   const selectOptions = [
-    { value: 'legacy-checkout', label: __( 'Legacy Checkout', 'storegrowth-sales-booster' ) },
-    { value: 'quick-cart-checkout', label: __( 'Quick Cart Checkout', 'storegrowth-sales-booster' ), disabled: upgradeTeaser },
+    {
+      value: "legacy-checkout",
+      label: __("Legacy Checkout", "storegrowth-sales-booster"),
+    },
+    {
+      value: "quick-cart-checkout",
+      label: __("Quick Cart Checkout", "storegrowth-sales-booster"),
+      needUpgrade:upgradeTeaser,
+      disabled: isQuickCartActive,
+    },
   ];
 
   return (
@@ -97,16 +107,20 @@ function General({ onFormSave, upgradeTeaser }) {
         />
 
         <SelectBox
-          fieldWidth={ upgradeTeaser ? 250 : 170 }
-          name={ "checkout_redirect" }
-          fieldValue={ upgradeTeaser ? 'legacy-checkout' : createDirectCheckoutFormData.checkout_redirect }
-          changeHandler={ upgradeTeaser ? noop : onFieldChange }
-          title={ __( 'Checkout Redirect', 'storegrowth-sales-boooster' ) }
+          fieldWidth={upgradeTeaser ? 250 : 170}
+          name={"checkout_redirect"}
+          fieldValue={
+            upgradeTeaser
+              ? "legacy-checkout"
+              : createDirectCheckoutFormData.checkout_redirect
+          }
+          changeHandler={upgradeTeaser ? noop : onFieldChange}
+          title={__("Checkout Redirect", "storegrowth-sales-boooster")}
           tooltip={__(
             "Select the type of checkout redirection",
             "storegrowth-sales-booster"
-          ) }
-          options={ selectOptions }
+          )}
+          options={selectOptions}
         />
 
         <SingleCheckBox
@@ -123,7 +137,9 @@ function General({ onFormSave, upgradeTeaser }) {
         />
         <SingleCheckBox
           name={"product_page_checkout_enable"}
-          checkedValue={createDirectCheckoutFormData.product_page_checkout_enable}
+          checkedValue={
+            createDirectCheckoutFormData.product_page_checkout_enable
+          }
           className={`settings-field checkbox-field`}
           changeHandler={onFieldChange}
           title={__("Display on Product Page", "storegrowth-sales-booster")}

--- a/includes/modules/direct-checkout/includes/class-enqueue-script.php
+++ b/includes/modules/direct-checkout/includes/class-enqueue-script.php
@@ -55,7 +55,7 @@ class Enqueue_Script {
 
 		$dir_checkout_settings = get_option( 'sgsb_direct_checkout_settings' );
 		$checkout_redirect     = sgsb_find_option_setting( $dir_checkout_settings, 'checkout_redirect', 'legacy-checkout' );
-		$is_checkout_redirect  = ( $checkout_redirect === 'quick-cart-checkout' );
+		$is_checkout_redirect  = ( 'quick-cart-checkout' === $checkout_redirect );
 		wp_localize_script(
 			'sgsb-dc-script',
 			'sgsbDcFrontend',
@@ -89,7 +89,7 @@ class Enqueue_Script {
 			false
 		);
 		$sgsb_active_module_ids  = get_option( 'sgsb_active_module_ids' );
-		$is_quick_cart_activated = array_key_exists( 'fly-cart', $sgsb_active_module_ids );
+		$is_quick_cart_activated = ! array_key_exists( 'fly-cart', $sgsb_active_module_ids );
 		wp_localize_script(
 			'sgsb-direct-checkout-settings',
 			'sgsbAdminQuickCartValidate',

--- a/includes/modules/direct-checkout/includes/class-enqueue-script.php
+++ b/includes/modules/direct-checkout/includes/class-enqueue-script.php
@@ -56,7 +56,6 @@ class Enqueue_Script {
 		$dir_checkout_settings = get_option( 'sgsb_direct_checkout_settings' );
 		$checkout_redirect     = sgsb_find_option_setting( $dir_checkout_settings, 'checkout_redirect', 'legacy-checkout' );
 		$is_checkout_redirect  = ( $checkout_redirect === 'quick-cart-checkout' );
-
 		wp_localize_script(
 			'sgsb-dc-script',
 			'sgsbDcFrontend',
@@ -85,6 +84,15 @@ class Enqueue_Script {
 			$settings_file['dependencies'],
 			$settings_file['version'],
 			false
+		);
+		$sgsb_active_module_ids  = get_option( 'sgsb_active_module_ids' );
+		$is_quick_cart_activated = array_key_exists( 'fly-cart', $sgsb_active_module_ids );
+		wp_localize_script(
+			'sgsb-direct-checkout-settings',
+			'sgsbAdminQuickCartValidate',
+			array(
+				'isQuickCartActivated' => $is_quick_cart_activated,
+			)
 		);
 	}
 

--- a/includes/modules/direct-checkout/includes/class-enqueue-script.php
+++ b/includes/modules/direct-checkout/includes/class-enqueue-script.php
@@ -61,7 +61,10 @@ class Enqueue_Script {
 			'sgsbDcFrontend',
 			array(
 				'isQuickCartCheckout' => $is_checkout_redirect,
-				'isPro'               => is_plugin_active( 'storegrowth-sales-booster-pro/storegrowth-sales-booster-pro.php' ),
+				'isPro'               => is_plugin_active(
+					'storegrowth-sales-booster-pro/storegrowth-sales-booster-pro.php',
+				),
+				'ajax_url'            => '/wp-admin/admin-ajax.php',
 			)
 		);
 	}


### PR DESCRIPTION
In this fix the direct chekcout state related issue has been fixed

If the quick cart is deactivated the Quick cart redirection selection will be disabled.
<img width="665" alt="image" src="https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/b2e0f113-2a67-45e0-bd4c-97bc8764bbee">

- [x]  Quick cart direct checkout redirection will be disable when the Quick cart module is deactivated(pro) [[link](https://www.evernote.com/shard/s744/sh/d112e006-05c9-4b3f-8a97-a04bfa4a7011/tCb8UJYcCXUmHPdXScvrCSqg0lG3xye4retXPMrk1XDtoeA4gt0cMBo6mQ)]
- [x]  Preview state is setting to default when the button layout is being changed ⏫
- [x]  Buy now Button redirect fix

resolves: #288