### PR TITLE
fix(sales-pop): text styling, state and content mismatch

### DIFF
--- a/assets/src/components/settings/Panels/PanelSettings/Fields/TextAreaBox.js
+++ b/assets/src/components/settings/Panels/PanelSettings/Fields/TextAreaBox.js
@@ -19,7 +19,8 @@ const TextAreaBox = ( {
     colSpan = 24,
     needUpgrade = false,
     upgradeOverlay =true,
-    inputRestrictor =false
+    inputRestrictor =false,
+    renderTextAreaContent =false
 } ) => {
     // Render textarea content after settings field, if needed.
     const renderAreaContent = applyFilters(
@@ -48,12 +49,12 @@ const TextAreaBox = ( {
                     disabled={ needUpgrade && upgradeOverlay }
                     placeholder={ placeHolderText }
                     value={ fieldValue ? fieldValue : '' }
-                    className={ `${ renderAreaContent !== '' ? 'field-gap' : '' } settings-field textarea-field` }
+                    className={ `${ renderTextAreaContent !== '' ? 'field-gap' : '' } settings-field textarea-field` }
                     onChange={ ( event ) => {inputRestrictor?
                     (event.nativeEvent.inputType==="deleteContentBackward"?changeHandler( name, event.target.value ):""):
                     changeHandler( name, event.target.value )} }
                 />
-                { renderAreaContent }
+                { renderTextAreaContent && renderAreaContent }
             </Col>
             <UpgradeOverlay /> 
         </FieldWrapper>

--- a/includes/modules/sales-pop/assets/src/components/Design.js
+++ b/includes/modules/sales-pop/assets/src/components/Design.js
@@ -116,7 +116,7 @@ function Design( { onFormSave, upgradeTeaser } ) {
           />
 
           {/* name text */ }
-          <TextDesign
+          {/* <TextDesign
             createPopupForm={ createPopupFormData }
             onFieldChange={ onFieldChange }
             textTitle='Shop Name Text'
@@ -126,7 +126,7 @@ function Design( { onFormSave, upgradeTeaser } ) {
             fontSize={ createPopupFormData.name_text_font_size }
             fontWeightName='name_text_font_weight'
             fontWeight={ createPopupFormData.name_text_font_weight }
-          />
+          /> */}
         </Fragment>
       ) }
 

--- a/includes/modules/sales-pop/assets/src/components/General.js
+++ b/includes/modules/sales-pop/assets/src/components/General.js
@@ -17,7 +17,7 @@ function General( { onFormSave, upgradeTeaser } ) {
 
   const onFieldChange = ( key, value ) => {
     setCreateFromData( {
-      ...createPopupForm,
+      ...createPopupFormData,
       [ key ]: value,
     } );
   };

--- a/includes/modules/sales-pop/assets/src/components/Message.js
+++ b/includes/modules/sales-pop/assets/src/components/Message.js
@@ -60,6 +60,7 @@ function Message( { onFormSave, upgradeTeaser } ) {
           changeHandler={ upgradeTeaser ? noop : onFieldChange }
           title={ __( 'Message Popup', 'storegrowth-sales-booster' ) }
           placeHolderText={ __( 'Enter Message Popup', 'storegrowth-sales-booster' ) }
+          renderTextAreaContent={true}
         />
       </SettingsSection>
 

--- a/includes/modules/sales-pop/assets/src/helper.js
+++ b/includes/modules/sales-pop/assets/src/helper.js
@@ -66,7 +66,7 @@ export const createPopupForm = {
     show_close_button            : true,
     external_link                : false,
     product_random               : false,
-    product_source               : 2,
+    product_source               : '1',
     virtual_name                 : [],
     virtual_time				 : 1,
     address                      : ['real'],

--- a/includes/modules/sales-pop/templates/popup-style.php
+++ b/includes/modules/sales-pop/templates/popup-style.php
@@ -36,7 +36,7 @@ $image_style         = "border-radius:$image_border_radius" . 'px';
 $time_color       = $popup_properties['time_text_color'];
 $time_font_size   = $popup_properties['time_text_font_size'] . 'px';
 $time_font_weight = $popup_properties['time_text_font_weight'];
-$time_style       = "color:$time_color;font-size:$time_font_size;font-weight:$name_font_weight";
+$time_style       = "color:$time_color;font-size:$time_font_size;font-weight:$time_font_weight";
 
 // Image spacing.
 $image_spacing = $popup_properties['spacing_around_image'];


### PR DESCRIPTION
In this commit there are several fix has been made.

state inconsitancy update
design realated issue updated

- [x]  general setting- activating one toggle another toggle is also getting deactivated ⏫
- [x]  Initial product source is getting an id number [[link](https://www.evernote.com/shard/s744/sh/44a0dd97-ed20-436b-b840-abf1914302f4/1N676aar4sMVwgWV0_2JU7FCOAqrYO_vF966RNKK61LwmkHjBfWBslCcqQ)]
- [x]  As there is no shop name showing in frontend admin shop name controller needs to removed.
- [x]  Time text not taking the Bold Effect
- [x]  In the text area the Message text is being shown [[link](https://www.evernote.com/shard/s744/sh/407a5260-5d0f-4304-90d3-d5e1cd90fae0/VNP0LCVd0H4HlKG4aBJxgUJglTaO4brU9Up_dEhOVQQ-8jX69ry8ikKVGg)]

resolves: #288