### PR TITLE
feat(fs-bar): icon color and state

### DIFF
--- a/includes/modules/progressive-discount-banner/assets/src/components/BarIcon.js
+++ b/includes/modules/progressive-discount-banner/assets/src/components/BarIcon.js
@@ -3,7 +3,7 @@ import { Fragment } from 'react';
 const BarIcon = ( { activeIcon, iconName, svgStyle, iconColor, preview = false } ) => {
     return (
         <Fragment>
-            { iconName === 'notify-bar-icon-1' && (
+            { iconName === 'shipping-bar-icon-1' && (
                 <svg
                     width={ `${ preview ? 32 : 20 }` }
                     height={ `${ preview ? 32 : 20 }` }
@@ -36,7 +36,7 @@ const BarIcon = ( { activeIcon, iconName, svgStyle, iconColor, preview = false }
                 </svg>
             ) }
 
-            { iconName === 'notify-bar-icon-2' && (
+            { iconName === 'shipping-bar-icon-2' && (
                 <svg
                     width={ `${ preview ? 32 : 22 }` }
                     height={ `${ preview ? 32 : 22 }` }
@@ -69,7 +69,7 @@ const BarIcon = ( { activeIcon, iconName, svgStyle, iconColor, preview = false }
                 </svg>
             ) }
 
-            { iconName === 'notify-bar-icon-3' && (
+            { iconName === 'shipping-bar-icon-3' && (
                 <svg
                     width={ `${ preview ? 32 : 22 }` }
                     height={ `${ preview ? 32 : 22 }` }

--- a/includes/modules/progressive-discount-banner/assets/src/components/DiscountBanner.js
+++ b/includes/modules/progressive-discount-banner/assets/src/components/DiscountBanner.js
@@ -66,9 +66,9 @@ function DiscountBanner(props) {
     const noop = () => {};
 
     const iconStyleNames = [
-        'notify-bar-icon-1',
-        'notify-bar-icon-2',
-        'notify-bar-icon-3',
+        'shipping-bar-icon-1',
+        'shipping-bar-icon-2',
+        'shipping-bar-icon-3',
     ];
 
     const iconOptions = iconStyleNames?.map( iconStyleName => (

--- a/includes/modules/progressive-discount-banner/assets/src/components/Preview.js
+++ b/includes/modules/progressive-discount-banner/assets/src/components/Preview.js
@@ -46,6 +46,7 @@ const Preview = ( { isProActive, formData, fontFamily } ) => {
                                 preview={ true }
                                 activeIcon={ formData?.progressive_banner_icon_name }
                                 iconName={ formData?.progressive_banner_icon_name }
+                                iconColor={formData?.icon_color}
                             />
                         ) }
                     </div>


### PR DESCRIPTION
in this commit the icon update, deafault icon, icon color changing and the sate is fixed.

- [x]  Icon Color not updating in the admin ui preview panel
- [x]  Close Button color not updating in frontend (Pro version)
- [x] By Default state no Icon is selected in the admin UI.
- [x] Selecting the template doesn't fully restore the state of the icon.

resolves: #288