### PR TITLE
fix(admin-ui): Plugin rename and plugin page dashboard link

### DIFF
--- a/assets/src/admin.css
+++ b/assets/src/admin.css
@@ -10,19 +10,19 @@ body {
     line-height: 1.4em;
 }
 
-.sales-booster_page_sgsb-modules #wpcontent, .sales-booster_page_sgsb-settings #wpcontent {
+.storegrowth_page_sgsb-modules #wpcontent, .storegrowth_page_sgsb-settings #wpcontent {
     background: #F4F7FF;
     padding-left: 14px !important;
 
 }
 
-.sales-booster_page_sgsb-modules #wpcontent .wrap, .sales-booster_page_sgsb-settings #wpcontent .wrap {
+.storegrowth_page_sgsb-modules #wpcontent .wrap, .storegrowth_page_sgsb-settings #wpcontent .wrap {
     /* margin: 0; */
 
 }
 
-.sales-booster_page_sgsb-modules #wpcontent #sbooster-modules-page .ant-layout, 
-.sales-booster_page_sgsb-settings #sbooster-settings-page .ant-layout {
+.storegrowth_page_sgsb-modules #wpcontent #sbooster-modules-page .ant-layout, 
+.storegrowth_page_sgsb-settings #sbooster-settings-page .ant-layout {
     background: #F4F7FF;
 }
 

--- a/includes/admin/class-admin-hooks.php
+++ b/includes/admin/class-admin-hooks.php
@@ -37,7 +37,7 @@ class Admin_Hooks {
 	 */
 	public function plugin_action_links( $links ) {
 		$action_links = array(
-			'dashboard' => '<a href="' . admin_url( 'admin.php?page=sgsb-dashboard' ) . '">' . esc_html__( 'Dashboard', 'storegrowth-sales-booster' ) . '</a>',
+			'dashboard' => '<a href="' . admin_url( 'admin.php?page=sgsb-settings#/dashboard/overview' ) . '">' . esc_html__( 'Dashboard', 'storegrowth-sales-booster' ) . '</a>',
 			'modules'   => '<a href="' . admin_url( 'admin.php?page=sgsb-modules' ) . '">' . esc_html__( 'Modules', 'storegrowth-sales-booster' ) . '</a>',
 			'settings'  => '<a href="' . admin_url( 'admin.php?page=sgsb-settings' ) . '">' . esc_html__( 'Settings', 'storegrowth-sales-booster' ) . '</a>',
 		);

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -41,22 +41,21 @@ class Admin_Menu {
 	public function highlight_admin_submenu( $submenu_file ) {
 		global $current_screen;
 
-//        error_log( print_r( $current_screen->id, 1 ) );
-
-		if ( $current_screen->id === 'sales-booster_page_sgsb-dashboard' ) {
+		if ( 'storegrowth_page_sgsb-dashboard' === $current_screen->id ) {
 			$submenu_file = 'admin.php?page=sgsb-settings#/dashboard/overview';
 		}
 
 		return $submenu_file;
 	}
 
+
 	/**
 	 * Register a custom menu page.
 	 */
 	public function register_admin_menu() {
 		add_menu_page(
-			__( 'Sales Booster', 'storegrowth-sales-booster' ),
-			__( 'Sales Booster', 'storegrowth-sales-booster' ),
+			__( 'StoreGrowth', 'storegrowth-sales-booster' ),
+			__( 'StoreGrowth', 'storegrowth-sales-booster' ),
 			'manage_options',
 			'sales-booster-for-woocommerce',
 			array( $this, 'modules_callback' ),
@@ -66,7 +65,7 @@ class Admin_Menu {
 
 		add_submenu_page(
 			'sales-booster-for-woocommerce',
-			__( 'Dashboard - Sales Booster', 'storegrowth-sales-booster' ),
+			__( 'Dashboard - StoreGrowth', 'storegrowth-sales-booster' ),
 			__( 'Dashboard', 'storegrowth-sales-booster' ),
 			'manage_options',
 			'sgsb-settings#/dashboard/overview',
@@ -75,7 +74,7 @@ class Admin_Menu {
 
 		add_submenu_page(
 			'sales-booster-for-woocommerce',
-			__( 'Modules - Sales Booster', 'storegrowth-sales-booster' ),
+			__( 'Modules - StoreGrowth', 'storegrowth-sales-booster' ),
 			__( 'Modules', 'storegrowth-sales-booster' ),
 			'manage_options',
 			'sgsb-modules',
@@ -84,14 +83,14 @@ class Admin_Menu {
 
 		add_submenu_page(
 			'sales-booster-for-woocommerce',
-			__( 'Settings - Sales Booster', 'storegrowth-sales-booster' ),
+			__( 'Settings - StoreGrowth', 'storegrowth-sales-booster' ),
 			__( 'Settings', 'storegrowth-sales-booster' ),
 			'manage_options',
 			'sgsb-settings',
 			array( $this, 'settings_callback' )
 		);
 
-		// Remove own submenu of `Sales Booster`.
+		// Remove own submenu of `StoreGrowth`.
 		remove_submenu_page( 'sales-booster-for-woocommerce', 'sales-booster-for-woocommerce' );
 	}
 
@@ -117,5 +116,4 @@ class Admin_Menu {
 		wp_safe_redirect( $redirect_url );
 		exit;
 	}
-
 }

--- a/includes/class-enqueue.php
+++ b/includes/class-enqueue.php
@@ -26,14 +26,14 @@ class Enqueue {
 	 *
 	 * @var string
 	 */
-	private $modules_page_hook = 'sales-booster_page_sgsb-modules';
+	private $modules_page_hook = 'storegrowth_page_sgsb-modules';
 
 	/**
 	 * Module settings page slug.
 	 *
 	 * @var string
 	 */
-	private $settings_page_hook = 'sales-booster_page_sgsb-settings';
+	private $settings_page_hook = 'storegrowth_page_sgsb-settings';
 
 	/**
 	 * Constructor of Enqueue class.

--- a/includes/modules/countdown-timer/includes/class-enqueue-script.php
+++ b/includes/modules/countdown-timer/includes/class-enqueue-script.php
@@ -72,7 +72,7 @@ class Enqueue_Script {
 	 * @param string $hook Page slug.
 	 */
 	public function admin_enqueue_scripts( $hook ) {
-		if ( 'sales-booster_page_sgsb-settings' !== $hook ) {
+		if ( 'storegrowth_page_sgsb-settings' !== $hook ) {
 			return;
 		}
 

--- a/includes/modules/direct-checkout/includes/class-enqueue-script.php
+++ b/includes/modules/direct-checkout/includes/class-enqueue-script.php
@@ -73,7 +73,7 @@ class Enqueue_Script {
 	 * @param string $hook Page slug.
 	 */
 	public function admin_enqueue_scripts( $hook ) {
-		if ( 'sales-booster_page_sgsb-settings' !== $hook ) {
+		if ( 'storegrowth_page_sgsb-settings' !== $hook ) {
 			return;
 		}
 

--- a/includes/modules/floating-notification-bar/includes/class-enqueue-script.php
+++ b/includes/modules/floating-notification-bar/includes/class-enqueue-script.php
@@ -68,7 +68,7 @@ class Enqueue_Script {
 	 * @param string $hook Page slug.
 	 */
 	public function admin_enqueue_scripts( $hook ) {
-		if ( 'sales-booster_page_sgsb-settings' === $hook ) {
+		if ( 'storegrowth_page_sgsb-settings' === $hook ) {
 			$settings_file = require sgsb_modules_path( 'floating-notification-bar/assets/build/settings.asset.php' );
 
 			wp_enqueue_media();

--- a/includes/modules/fly-cart/includes/class-enqueue-script.php
+++ b/includes/modules/fly-cart/includes/class-enqueue-script.php
@@ -85,7 +85,7 @@ class Enqueue_Script {
 	 * @param string $hook Page slug.
 	 */
 	public function admin_enqueue_scripts( $hook ) {
-		if ( 'sales-booster_page_sgsb-settings' === $hook ) {
+		if ( 'storegrowth_page_sgsb-settings' === $hook ) {
 			// Add the color picker css file.
 			wp_enqueue_style( 'wp-color-picker' );
 

--- a/includes/modules/progressive-discount-banner/includes/class-enqueue-script.php
+++ b/includes/modules/progressive-discount-banner/includes/class-enqueue-script.php
@@ -69,7 +69,7 @@ class Enqueue_Script {
 	 * @param string $hook Page slug.
 	 */
 	public function admin_enqueue_scripts( $hook ) {
-		if ( 'sales-booster_page_sgsb-settings' === $hook ) {
+		if ( 'storegrowth_page_sgsb-settings' === $hook ) {
 			$settings_file = require sgsb_modules_path( 'progressive-discount-banner/assets/build/settings.asset.php' );
 
 			wp_enqueue_media();

--- a/includes/modules/sales-pop/includes/class-enqueue.php
+++ b/includes/modules/sales-pop/includes/class-enqueue.php
@@ -119,7 +119,7 @@ class Enqueue {
 	public function admin_enqueue_scripts( $screen ) {
 		$popup_properties = maybe_unserialize( get_option( 'sgsb_popup_products', true ) );
 
-		if ( 'sales-booster_page_sgsb-settings' === $screen ) {
+		if ( 'storegrowth_page_sgsb-settings' === $screen ) {
 			add_action( 'admin_head', array( $this, 'admin_css' ) );
 			$settings_file = require sgsb_modules_path( 'sales-pop/assets/build/settings.asset.php' );
 

--- a/includes/modules/stock-bar/includes/class-enqueue-script.php
+++ b/includes/modules/stock-bar/includes/class-enqueue-script.php
@@ -72,7 +72,7 @@ class Enqueue_Script {
 	 * @param string $hook Page slug.
 	 */
 	public function admin_enqueue_scripts( $hook ) {
-		if ( 'sales-booster_page_sgsb-settings' !== $hook ) {
+		if ( 'storegrowth_page_sgsb-settings' !== $hook ) {
 			return;
 		}
 

--- a/includes/modules/upsell-order-bump/includes/class-enqueue-script.php
+++ b/includes/modules/upsell-order-bump/includes/class-enqueue-script.php
@@ -40,7 +40,7 @@ class Enqueue_Script {
 	 */
 	public function admin_enqueue_scripts( $hook ) {
 
-		if ( 'sales-booster_page_sgsb-settings' === $hook ) {
+		if ( 'storegrowth_page_sgsb-settings' === $hook ) {
 
 			$settings_file                   = require sgsb_modules_path( 'upsell-order-bump/assets/build/settings.asset.php' );
 			$settings_file['dependencies'][] = 'jquery';


### PR DESCRIPTION
In this commit the admin UI plugin name and the plugin page dashboard redirection page link is fixed.
Admin UI

 - [x] Plugin Rename from Sales Booster to Store Growth
 - [x] Plugin page Dashboard  link redirection fix
 
resolves: #288