### PR TITLE
fix(quick-cart): Design Styling fix

### DIFF
--- a/includes/modules/fly-cart/assets/css/wfc-style.css
+++ b/includes/modules/fly-cart/assets/css/wfc-style.css
@@ -6,43 +6,44 @@
 @import url('../font/inter-bold/stylesheet.css');
 
 
+
 /*=======================
-* WFC STYLES
+* Quick cart Icon Style wrapper
 ========================*/
+/* Quick cart icon  */
 .wfc-cart-icon {
     position: fixed;
     display: inline-block;
     z-index: 999;
-    width: 50px;
-    height: 50px;
     border-radius: 4px
 }
-.bottom-left{
+.wfc-cart-icon.bottom-left{
     bottom: 60px;
     left: 60px;
 }
-.bottom-right{
+.wfc-cart-icon.bottom-right{
     bottom: 60px;
     right: 60px;
 }
-.top-right{
+.wfc-cart-icon.top-right{
     top: 60px;
     right: 60px;
 }
-.top-left{
+.wfc-cart-icon.top-left{
     top: 60px;
     left: 60px;
 }
 .wfc-cart-icon .wfc-icon {
-    color: #2ecc71;
     cursor: pointer;
 }
 .wfc-cart-icon .wfc-icon svg{
-    padding: 10px !important;
+    width: 46px !important;
+    height: 46px !important;
+    padding: 5px !important;
 }
 
-.wfc-icon:before,
-.wfc-icon:after {
+.wfc-cart-icon.wfc-icon:before,
+.wfc-cart-icon.wfc-icon:after {
     font-size: 25px;
     line-height: 50px;
     margin-left: 0;
@@ -65,27 +66,60 @@
     font-weight: 600;
 }
 
-.qc-cart-heading{
+/*=======================
+* Quick cart content Slider
+========================*/
+.wfc-widget-sidebar {
+    position: fixed;
+    padding: 18px 0px !important;
+    z-index: 1001;
+    box-shadow: -2px 0px 9px 0px rgba(184,184,184,1);
+    transition:  1s ease; 
+}
+
+.wfc-overlay {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0.83);
+    top: 0;
+    left: 0;
+    z-index: 1000;
+}
+
+.wfc-hide {
+    display: none;
+}
+
+.wfc-slide{
+    right: -800px !important;
+}
+
+/*=======================
+* Quick cart content Wrapper
+========================*/
+.wfc-widget-sidebar .qc-cart-heading{
     position:sticky;
     padding: 0px 30px;
 }
 
-.wfc-cart-heading{
+.wfc-widget-sidebar .qc-cart-heading .wfc-cart-heading{
     color: #073B4C;
     font-size: 40px;
     font-weight: 600;
     margin-bottom: 5px;
+    margin-top: 0px;
     font-family: 'Inter';
     letter-spacing: 0.7px;
 }
 
-.sgsb-widget-shopping-cart-content-wrapper {
-    height:90%;
-    width: 100%;
+.wfc-widget-sidebar .sgsb-widget-shopping-cart-content-wrapper {
     overflow-y: scroll;
     padding: 0px 30px;
 }
-
+.sgsb-widget-shopping-cart-content {
+    max-width: 100%;
+}
 .sgsb-widget-shopping-cart-content-wrapper span.sgsb-cart-item-count {
     display: block;
     font-weight: 500;
@@ -103,21 +137,22 @@
 
 
 /* Cart Table */
-table.sgsb-fly-cart-table {
+.sgsb-widget-shopping-cart-content .sgsb-woocommerce-cart-form table.sgsb-fly-cart-table {
     border: 0 none;
     min-width: initial;
     width: 100%;
 }
-tr.woocommerce-cart-form__cart-item.cart_item {
-    position: relative;
-    margin-top: 18px;
+.sgsb-widget-shopping-cart-content .sgsb-woocommerce-cart-form .sgsb-fly-cart-table tr.woocommerce-cart-form__cart-item.cart_item {
+    margin-top: 10px;
     margin-bottom: 6px;
     padding: 16px;
     display: flex;
+    justify-content: space-between;
     border-radius: 10px;
     background: rgb(255, 255, 255);
     align-items: center;
     border: 1px solid rgb(221, 230, 249);
+    width: -webkit-fill-available;
 }
 .sgsb-fly-cart-table td {
     border: 0 none;
@@ -189,7 +224,7 @@ tr.woocommerce-cart-form__cart-item.cart_item {
     text-align: center;
     padding: 0px 5px;
 }
-.sgsb-fly-cart-table .product-quantity button.sgsb-plus-icon {
+/* .sgsb-fly-cart-table .product-quantity button.sgsb-plus-icon {
     font-size: 25px;
     transition: .33s;
     cursor: pointer;
@@ -199,11 +234,12 @@ tr.woocommerce-cart-form__cart-item.cart_item {
     align-items: center;
     justify-content: center;
     color: rgb(7, 59, 76);
-}
-.sgsb-fly-cart-table .product-quantity button.sgsb-minus-icon {
+} */
+.sgsb-widget-shopping-cart-content-wrapper .sgsb-widget-shopping-cart-content .sgsb-woocommerce-cart-form .sgsb-fly-cart-table .product-quantity button.sgsb-minus-icon, .sgsb-widget-shopping-cart-content-wrapper .sgsb-widget-shopping-cart-content .sgsb-woocommerce-cart-form .sgsb-fly-cart-table .product-quantity button.sgsb-plus-icon{
     font-size: 30px;
     transition: .33s;
     text-decoration: none;
+    border: none;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -268,12 +304,7 @@ tr.woocommerce-cart-form__cart-item.cart_item {
     width: 40%;
     border: 0 none;
 }
-.sgsb-fly-cart-table .product-remove {
-    position: absolute;
-    right: 8px;
-    top: 50%;
-    transform: translateY(-50%);
-}
+
 .sgsb-fly-cart-table .product-remove a {
     font-size: 0;
     text-decoration: none;
@@ -372,7 +403,7 @@ tr.woocommerce-cart-form__cart-item.cart_item {
     display: none;
 }
 .sgsb-cart-collaterals table {
-    border: 0;
+    border: 0 !important;
     width: 100%;
 }
 
@@ -502,7 +533,7 @@ iframe.sgsb-fast-cart-checkout-frame {
 @media only screen and (min-width: 992px) and (max-width: 1199px) {
     .wfc-cart-heading {
         font-size: 34px;
-        padding: 0 0px 30px;
+        /* padding: 0 0px 30px; */
     }
 
     .wfc-widget-sidebar {
@@ -538,17 +569,24 @@ iframe.sgsb-fast-cart-checkout-frame {
 /* /		Tablet Layout: 768px.	/ */
 
 @media only screen and (min-width: 768px) and (max-width: 991px) {
-
-
+    
     .wfc-widget-sidebar {
         max-width: 100% !important;
     }
-    .sgsb-quick-cart-center-layout{
-        width: 100%;
+    .wfc-widget-sidebar .sgsb-widget-shopping-cart-content-wrapper {
+        width: 470px;
     }
-    .wfc-cart-heading {
-        padding: 0px 5px 20px;
-        font-size: 28px;
+    
+    .wfc-widget-sidebar.sgsb-quick-cart-center-layout .sgsb-widget-shopping-cart-content-wrapper {
+        width: 560px !important;
+    }
+
+    .wfc-widget-sidebar .qc-cart-heading {
+        padding: 0px 20px;
+    }
+
+    .wfc-widget-sidebar .qc-cart-heading .wfc-cart-heading {
+        font-size: 28px !important;
     }
     .wfc-close-btn {
         margin-top: -10px;
@@ -557,7 +595,7 @@ iframe.sgsb-fast-cart-checkout-frame {
         padding: 10px;
     }
     .sgsb-widget-shopping-cart-content-wrapper {
-        padding: 0 38px 50px;
+        padding: 0px 20px !important;
     }
     .sgsb-fly-cart-table td.product-name .sgsb-product-title {
         font-size: 16px;
@@ -586,9 +624,9 @@ iframe.sgsb-fast-cart-checkout-frame {
     .woocommerce table.shop_table_responsive tr td::before,
      .woocommerce-page table.shop_table_responsive tr.cart-subtotal td::before {
         font-size: 17px;
-        color: #dddddd !important;
+        color: #345f6f !important;
         font-weight: 500 !important;
-    }
+    } 
     .woocommerce table.shop_table_responsive tr td::before, .woocommerce-page table.shop_table_responsive tr.order-total td ::before {
         font-size: 17px;
         color: #000!important;
@@ -613,25 +651,22 @@ iframe.sgsb-fast-cart-checkout-frame {
 /* /		Mobile Layout: 320px.    / */
 
 @media only screen and (max-width: 767px) {
-
-    .wfc-widget-sidebar {
-        width: 100% !important;
-    }
-    .sgsb-quick-cart-center-layout{
-        width:100% !important;
-    }
-    .qc-cart-heading {
-        padding: 0px 5px;
+    .wfc-widget-sidebar .qc-cart-heading {
+        padding: 0px 20px !important;
     }
 
-    .wfc-cart-heading {
-        padding: 0 0px 15px;
-        font-size: 25px;
+    .wfc-widget-sidebar .qc-cart-heading .wfc-cart-heading {
+        font-size: 24px !important;
+    }
+    .wfc-widget-sidebar .qc-cart-heading .wfc-cart-heading .sgsb-cart-widget-close{
+        font-size: 24px !important;
     }
 
-    .sgsb-widget-shopping-cart-content-wrapper {
-        padding: 0 15px 48px;
+    .wfc-widget-sidebar .sgsb-widget-shopping-cart-content-wrapper {
+        padding: 0  20px !important;
+        width: 80vw;
     }
+   
     
     .sgsb-fly-cart-table td.product-name .sgsb-product-title {
         font-size: 16px;
@@ -646,6 +681,8 @@ iframe.sgsb-fast-cart-checkout-frame {
 
     .woocommerce table.shop_table_responsive tr td::before,
     .woocommerce-page table.shop_table_responsive tr.cart-subtotalz td::before {
+        color: #345f6f !important;
+        
        font-size: 17px;
     }
     .woocommerce table.shop_table_responsive tr td::before, .woocommerce-page table.shop_table_responsive tr.order-total td ::before {
@@ -658,8 +695,8 @@ iframe.sgsb-fast-cart-checkout-frame {
     }
 
     .sgsb-fly-cart-table td.product-thumbnail img {
-        width: 100%;
-        height: 100%;
+        width: 60%;
+        height: 60%;
     }
     .sgsb-fly-cart-table .product-quantity button.sgsb-minus-icon {
         padding: 0px 1px;
@@ -715,6 +752,10 @@ iframe.sgsb-fast-cart-checkout-frame {
     .sgsb-fly-cart-table .product-remove {
         right: 5px;
     }
+
+    .sgsb-widget-shopping-cart-content-wrapper .sgsb-cart-widget-buttons a{
+        font-size: 14px !important;
+    }
    
 
     
@@ -728,9 +769,9 @@ iframe.sgsb-fast-cart-checkout-frame {
 }
 
 ::-webkit-scrollbar-thumb {
-    background: #000000;
+    background: transparent;
     -webkit-border-radius: 1ex;
-    -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.75);
+    -webkit-box-shadow: none;
 }
 /* 
 ::-webkit-scrollbar-corner {

--- a/includes/modules/fly-cart/assets/css/wfc-style.css
+++ b/includes/modules/fly-cart/assets/css/wfc-style.css
@@ -117,6 +117,33 @@
     overflow-y: scroll;
     padding: 0px 30px;
 }
+
+.wfc-widget-sidebar .sgsb-widget-shopping-cart-content-wrapper .sgsb-widget-shopping-cart-content .woocommerce-info ,
+.wfc-widget-sidebar .sgsb-widget-shopping-cart-content-wrapper .sgsb-widget-shopping-cart-content .woocommerce-message,
+.wfc-widget-sidebar .sgsb-widget-shopping-cart-content-wrapper .sgsb-widget-shopping-cart-content .woocommerce-error{
+    background-color: #ffffff;
+    color: #222;
+    border-top-width: 0px !important;
+    padding: 1rem 1.5rem 1rem 3.5rem !important;
+    margin-bottom: 2rem !important;
+    list-style: none;
+    position: relative;
+    text-align: center !important;
+    font-weight: 500 !important;
+    font-size: 18px !important;
+    border-radius: 10px !important;
+    margin-top: 2rem !important;
+}
+
+.wfc-widget-sidebar .sgsb-widget-shopping-cart-content-wrapper .sgsb-widget-shopping-cart-content .return-to-shop .wp-element-button{
+    background-color: #073B4C;
+    border-width: 0;
+    border-radius: 6px !important;
+    padding: 14px !important;
+    color: #ffffff !important;
+    font-weight: 600 !important;
+}
+
 .sgsb-widget-shopping-cart-content {
     max-width: 100%;
 }

--- a/includes/modules/fly-cart/assets/js/wfc-script.js
+++ b/includes/modules/fly-cart/assets/js/wfc-script.js
@@ -79,7 +79,7 @@
   // For sidebar.
   jQuery(document).ready(function () {
     // Dynamic Height Calculation
-    let adminBarHeight = document.getElementById("wpadminbar") ? 0 : 40;
+    let adminBarHeight = document.getElementById("wpadminbar") ? 20 : 40;
     let extraHeight = sgsbFrontend?.cartLayoutType === "center" ? 150 : 82;
     function setDynamicHeight() {
       var deductableHeight =

--- a/includes/modules/fly-cart/assets/js/wfc-script.js
+++ b/includes/modules/fly-cart/assets/js/wfc-script.js
@@ -3,12 +3,12 @@
 
   //Variable to set Timeout
   var timeoutId;
-
   // For flyout.
-  $(".products").flyto({
+  let flyToSelector = ".products-block-post-template, .products";
+  $(flyToSelector).flyto({
     item: "li.product",
     target: ".wfc-cart-icon .wfc-icon",
-    button: ".product_type_simple.add_to_cart_button",
+    button: ".add_to_cart_button.product_type_simple",
     shake: true,
   });
 
@@ -109,10 +109,10 @@
       jQuery(".wfc-overlay").addClass("wfc-hide");
       jQuery(".wfc-widget-sidebar").addClass("wfc-slide");
     });
-
     const { checkoutRedirect, quickCartRedirect, isPro } = sgsbFrontend;
     // If quick cart redirection selected from direct checkout then trigger quick cart for checkout/buy-now button.
     if (isPro && Boolean(checkoutRedirect)) {
+      
       jQuery(".sgsb_buy_now_button, .sgsb_buy_now_button_product_page").on(
         "click",
         function (event) {

--- a/includes/modules/fly-cart/assets/js/wfc-script.js
+++ b/includes/modules/fly-cart/assets/js/wfc-script.js
@@ -9,28 +9,30 @@
     item: "li.product",
     target: ".wfc-cart-icon .wfc-icon",
     button: ".product_type_simple.add_to_cart_button",
-    shake: true
+    shake: true,
   });
 
   /**
    * Set Fly Cart Contents.
    */
-  function setCartContents( response ) {
-    $( '.sgsb-widget-shopping-cart-content' ).html( response?.data?.htmlResponse );
-    $( '.wfc-cart-icon .wfc-cart-countlocation' ).html( response?.data?.cartCountLocation );
+  function setCartContents(response) {
+    $(".sgsb-widget-shopping-cart-content").html(response?.data?.htmlResponse);
+    $(".wfc-cart-icon .wfc-cart-countlocation").html(
+      response?.data?.cartCountLocation
+    );
 
-    setTimeout( function() {
-      $( '.sgsb-fly-cart-loader' ).addClass( 'wfc-hide' );
-    }, 500 );
+    setTimeout(function () {
+      $(".sgsb-fly-cart-loader").addClass("wfc-hide");
+    }, 500);
 
-    jQuery( document.body ).trigger( 'wc_fragment_refresh' );
+    jQuery(document.body).trigger("wc_fragment_refresh");
   }
 
   /**
    * Get Cart Contents.
    */
   function getCartContents() {
-    $('.sgsb-fly-cart-loader').removeClass('wfc-hide');
+    $(".sgsb-fly-cart-loader").removeClass("wfc-hide");
     $.ajax({
       url: sgsbFrontend.ajaxUrl,
       method: "POST",
@@ -39,7 +41,7 @@
         _ajax_nonce: sgsbFrontend.nonce,
         method: "get_cart_contents",
       },
-      success: setCartContents
+      success: setCartContents,
     });
   }
 
@@ -47,180 +49,212 @@
    * Update product quantity.
    */
   function updateProductQuantity(operator) {
-    var inputElm = $(this).parent().find('input.qty');
+    var inputElm = $(this).parent().find("input.qty");
     var inputVal = Number(inputElm.val());
-    var newVal = operator === 'plus' ? inputVal + 1 : inputVal - 1;
+    var newVal = operator === "plus" ? inputVal + 1 : inputVal - 1;
 
     if (newVal < 1) {
       return;
     }
 
     // Update input value & trigger the 'input' event.
-    inputElm.val(newVal).trigger('input');
+    inputElm.val(newVal).trigger("input");
   }
 
-  const triggerQuickCartPopup = ( targetDom ) => {
-    jQuery( targetDom ).on( 'click', function ( event ) {
+  const triggerQuickCartPopup = (targetDom) => {
+    jQuery(targetDom).on("click", function (event) {
       event.preventDefault();
-      jQuery('.wfc-overlay').removeClass('wfc-hide');
-      jQuery('.wfc-widget-sidebar').removeClass('wfc-slide');
+      jQuery(".wfc-overlay").removeClass("wfc-hide");
+      jQuery(".wfc-widget-sidebar").removeClass("wfc-slide");
       getCartContents();
     });
-  }
+  };
 
   const triggerAddToQuickCart = () => {
-    jQuery( '.product' ).on( 'click', '.add_to_cart_button', () => {
-      setTimeout( () => $( '.wfc-open-btn' ).click(), 2000 );
-    } );
-  }
+    jQuery(".product").on("click", ".add_to_cart_button", () => {
+      setTimeout(() => $(".wfc-open-btn").click(), 2000);
+    });
+  };
 
   // For sidebar.
   jQuery(document).ready(function () {
-    triggerQuickCartPopup( '.wfc-open-btn' );
-    jQuery('.wfc-overlay').on('click', function () {
-      jQuery(this).addClass('wfc-hide');
-      jQuery('.wfc-widget-sidebar').addClass('wfc-slide');
+    // Dynamic Height Calculation
+    let adminBarHeight = document.getElementById("wpadminbar") ? 0 : 40;
+    let extraHeight = sgsbFrontend?.cartLayoutType === "center" ? 150 : 82;
+    function setDynamicHeight() {
+      var deductableHeight =
+        $(".qc-cart-heading").height() + extraHeight - adminBarHeight;
+      var windowHeight = $(window).innerHeight();
+      $(".sgsb-widget-shopping-cart-content-wrapper").css(
+        "height",
+        windowHeight - deductableHeight
+      );
+    }
+
+    // Call the function on document ready
+    setDynamicHeight();
+
+    // Attach the function to the window resize event
+    $(window).resize(function () {
+      setDynamicHeight();
     });
-    jQuery(document).on('click', '.sgsb-cart-widget-close', function (event) {
+
+    triggerQuickCartPopup(".wfc-open-btn");
+    jQuery(".wfc-overlay").on("click", function () {
+      jQuery(this).addClass("wfc-hide");
+      jQuery(".wfc-widget-sidebar").addClass("wfc-slide");
+    });
+    jQuery(document).on("click", ".sgsb-cart-widget-close", function (event) {
       event.preventDefault();
-      jQuery('.wfc-overlay').addClass('wfc-hide');
-      jQuery('.wfc-widget-sidebar').addClass('wfc-slide');
+      jQuery(".wfc-overlay").addClass("wfc-hide");
+      jQuery(".wfc-widget-sidebar").addClass("wfc-slide");
     });
 
     const { checkoutRedirect, quickCartRedirect, isPro } = sgsbFrontend;
     // If quick cart redirection selected from direct checkout then trigger quick cart for checkout/buy-now button.
-    if ( isPro && Boolean( checkoutRedirect ) ) {
-      jQuery( '.sgsb_buy_now_button, .sgsb_buy_now_button_product_page' ).on( 'click', function ( event ) {
-        event.preventDefault();
-        const productId = jQuery( event?.target ).data( 'id' );
-        jQuery.ajax({
-          url     : wc_add_to_cart_params.ajax_url,
-          type    : 'POST',
-          data    : {
-            'action'     : 'woocommerce_add_to_cart',
-            'product_id' : productId,
-          },
-          success : ( response ) => {
-            jQuery('.wfc-overlay').removeClass('wfc-hide');
-            jQuery('.wfc-widget-sidebar').removeClass('wfc-slide');
-            getCartContents();
-          },
-          error   : ( error ) => console.log( error )
-        });
-      });
+    if (isPro && Boolean(checkoutRedirect)) {
+      jQuery(".sgsb_buy_now_button, .sgsb_buy_now_button_product_page").on(
+        "click",
+        function (event) {
+          event.preventDefault();
+          const productId = jQuery(event?.target).data("id");
+          jQuery.ajax({
+            url: wc_add_to_cart_params.ajax_url,
+            type: "POST",
+            data: {
+              action: "woocommerce_add_to_cart",
+              product_id: productId,
+            },
+            success: (response) => {
+              jQuery(".wfc-overlay").removeClass("wfc-hide");
+              jQuery(".wfc-widget-sidebar").removeClass("wfc-slide");
+              getCartContents();
+            },
+            error: (error) => console.log(error),
+          });
+        }
+      );
     }
 
     // Trigger quick cart if quick cart redirection enabled.
-    if ( Boolean( isPro ) && Boolean( quickCartRedirect ) ) triggerAddToQuickCart();
+    if (Boolean(isPro) && Boolean(quickCartRedirect)) triggerAddToQuickCart();
 
-    if(document.getElementById('wpadminbar')){
-      jQuery('.wfc-widget-sidebar').css('margin-top', '32px');
+    if (document.getElementById("wpadminbar")) {
+      jQuery(".wfc-widget-sidebar").css("margin-top", "20px");
     }
 
     // Handle cart form submit.
     $(document).on(
-      'submit',
-      'form.sgsb-woocommerce-cart-form',
+      "submit",
+      "form.sgsb-woocommerce-cart-form",
       function (event) {
         event.preventDefault();
-        $('.sgsb-fly-cart-loader').removeClass('wfc-hide');
+        $(".sgsb-fly-cart-loader").removeClass("wfc-hide");
 
         $.ajax({
           url: event.target.action,
           method: "POST",
           data: $(this).serialize(),
-          success: setCartContents
+          success: setCartContents,
         });
       }
     );
 
     // On plus icon click.
     $(document).on(
-      'click',
-      '.sgsb-fly-cart-table .product-quantity button.sgsb-plus-icon',
+      "click",
+      ".sgsb-fly-cart-table .product-quantity button.sgsb-plus-icon",
       function () {
-        updateProductQuantity.bind(this, 'plus').call();
+        updateProductQuantity.bind(this, "plus").call();
       }
     );
 
     // On minus icon click.
     $(document).on(
-      'click',
-      '.sgsb-fly-cart-table .product-quantity button.sgsb-minus-icon',
+      "click",
+      ".sgsb-fly-cart-table .product-quantity button.sgsb-minus-icon",
       function () {
-        updateProductQuantity.bind(this, 'minus').call();
+        updateProductQuantity.bind(this, "minus").call();
       }
     );
 
     // Restrict the input of other than numeric amd leading zero
-    $(document).on('input', 'input.qty', function () {
-      $(this).val(function (_, value) {
-        return value.replace(/^0*(?!$)/, ''); // Remove leading zeros if not the only character
-      });
-    }).on('keypress', 'input.qty', function (e) {
-      if (e.which === 48 && this.value === '0') {
-        return false; // Prevent input of additional leading zeros
-      }
-      if (String.fromCharCode(e.keyCode).match(/[^0-9]/g)) {
-        return false; // Prevent input of non-numeric characters
-      }
-    });
-    
-     
-    
-    // On input change fire up the submit 
-    $(document).on('input', 'input.qty', function() {
-        var inputValue = $(this).val();
-        clearTimeout(timeoutId);
-        // Set a new timeout to submit the form after 800 milliseconds
-        timeoutId = setTimeout(function() {
-        if (inputValue >= 1 && $(this)[0].getAttribute('value') !== inputValue) {
-          $('form.sgsb-woocommerce-cart-form').submit();
-        }else{
-          return;
+    $(document)
+      .on("input", "input.qty", function () {
+        $(this).val(function (_, value) {
+          return value.replace(/^0*(?!$)/, ""); // Remove leading zeros if not the only character
+        });
+      })
+      .on("keypress", "input.qty", function (e) {
+        if (e.which === 48 && this.value === "0") {
+          return false; // Prevent input of additional leading zeros
         }
-      }.bind(this), 800);
+        if (String.fromCharCode(e.keyCode).match(/[^0-9]/g)) {
+          return false; // Prevent input of non-numeric characters
+        }
+      });
+
+    // On input change fire up the submit
+    $(document).on("input", "input.qty", function () {
+      var inputValue = $(this).val();
+      clearTimeout(timeoutId);
+      // Set a new timeout to submit the form after 800 milliseconds
+      timeoutId = setTimeout(
+        function () {
+          if (
+            inputValue >= 1 &&
+            $(this)[0].getAttribute("value") !== inputValue
+          ) {
+            $("form.sgsb-woocommerce-cart-form").submit();
+          } else {
+            return;
+          }
+        }.bind(this),
+        800
+      );
     });
 
     // Remove product from cart.
     $(document).on(
-      'click',
-      'form.sgsb-woocommerce-cart-form a.sgsb-fly-cart-remove',
+      "click",
+      "form.sgsb-woocommerce-cart-form a.sgsb-fly-cart-remove",
       function (event) {
         event.preventDefault();
-        $('.sgsb-fly-cart-loader').removeClass('wfc-hide');
+        $(".sgsb-fly-cart-loader").removeClass("wfc-hide");
 
         $.ajax({
-          url: $(this).attr('href'),
+          url: $(this).attr("href"),
           method: "GET",
-          success: setCartContents
+          success: setCartContents,
         });
       }
     );
 
     function openCheckoutPageCallback(href) {
       // Show loader.
-      $('.sgsb-fly-cart-loader').removeClass('wfc-hide');
-      $('.sgsb-widget-shopping-cart-content').html("");
+      $(".sgsb-fly-cart-loader").removeClass("wfc-hide");
+      $(".sgsb-widget-shopping-cart-content").html("");
 
-      let checkoutFrame = document.createElement('iframe');
-      checkoutFrame.classList.add('sgsb-fast-cart-checkout-frame');
-      checkoutFrame.style.height = '80vh';
+      let checkoutFrame = document.createElement("iframe");
+      checkoutFrame.classList.add("sgsb-fast-cart-checkout-frame");
+      checkoutFrame.style.height = "80vh";
 
       let url = new URL(href);
-      url.searchParams.set('sgsb-checkout', 'true');
+      url.searchParams.set("sgsb-checkout", "true");
 
       checkoutFrame.src = url;
-      $(checkoutFrame).on('load', function() {
+      $(checkoutFrame).on("load", function () {
         const iframeDocument = checkoutFrame?.contentWindow?.document;
         const iframeBody = iframeDocument?.body;
-        const ifrmaeStyle = iframeDocument.createElement('style');
+        const ifrmaeStyle = iframeDocument.createElement("style");
         ifrmaeStyle.innerHTML = `
         #wpadminbar,header,.custom-social-proof,footer{
             display:none !important;
         }
         `;
-        iframeBody.style.backgroundColor = $(".wfc-widget-sidebar").css("background-color");
+        iframeBody.style.backgroundColor = $(".wfc-widget-sidebar").css(
+          "background-color"
+        );
         iframeDocument.head.appendChild(ifrmaeStyle);
       });
 
@@ -230,7 +264,7 @@
         if (checkoutFrame.isAttached) {
           checkoutFrame.style.opacity = 1;
           // Hide loader.
-          $('.sgsb-fly-cart-loader').addClass('wfc-hide');
+          $(".sgsb-fly-cart-loader").addClass("wfc-hide");
         }
       };
 
@@ -239,17 +273,16 @@
       if (checkoutFrame.isLoaded) {
         checkoutFrame.style.opacity = 1;
         // Hide loader.
-        $('.sgsb-fly-cart-loader').addClass('wfc-hide');
+        $(".sgsb-fly-cart-loader").addClass("wfc-hide");
       }
 
-      $('.sgsb-widget-shopping-cart-content').html(checkoutFrame);
-
+      $(".sgsb-widget-shopping-cart-content").html(checkoutFrame);
     }
 
     // Open checkout page.
     $(document).on(
-      'click',
-      '.wfc-widget-sidebar a.sgsb-cart-widget-checkout-button',
+      "click",
+      ".wfc-widget-sidebar a.sgsb-cart-widget-checkout-button",
       function (event) {
         event.preventDefault();
 
@@ -257,9 +290,13 @@
       }
     );
 
-    if ( Boolean( isPro ) ) {
+    if (Boolean(isPro)) {
       // Pass quick cart data to pro.
-      window.qcart = { checkoutRedirect, quickCartRedirect, addToQuickCart: triggerAddToQuickCart };
+      window.qcart = {
+        checkoutRedirect,
+        quickCartRedirect,
+        addToQuickCart: triggerAddToQuickCart,
+      };
     }
   });
 })(jQuery);

--- a/includes/modules/fly-cart/assets/src/components/DesignSettings.js
+++ b/includes/modules/fly-cart/assets/src/components/DesignSettings.js
@@ -3,6 +3,7 @@ import { Button, Form, Input, Select, Typography } from "antd";
 import SelectBox from "sales-booster/src/components/settings/Panels/PanelSettings/Fields/SelectBox";
 import ColourPicker from "sales-booster/src/components/settings/Panels/PanelSettings/Fields/ColorPicker";
 import SettingsSection from "sales-booster/src/components/settings/Panels/PanelSettings/SettingsSection";
+import ActionsHandler from "sales-booster/src/components/settings/Panels/PanelSettings/ActionsHandler";
 import RadioBox from "sales-booster/src/components/settings/Panels/PanelSettings/Fields/RadioBox";
 import CartIcon from "./CartIcon";
 
@@ -11,6 +12,7 @@ const DesignSettings = ({
     onFieldChange,
     onFormSave,
     buttonLoading,
+    onFormReset
 }) => {
     const iconPositions = [
         { value: 'top-left', label: __( 'Top Left', 'storegrowth-sales-booster' ) },
@@ -70,6 +72,11 @@ const DesignSettings = ({
                 fieldValue={ formData.widget_bg_color }
                 title={ __( 'Widget Background Color', 'storegrowth-sales-booster' ) }
             />
+        <ActionsHandler
+          saveHandler={ onFormSave }
+          resetHandler={ onFormReset }
+          loadingHandler={ buttonLoading }
+        />
         </SettingsSection>
     );
 }

--- a/includes/modules/fly-cart/assets/src/components/GeneralSettings.js
+++ b/includes/modules/fly-cart/assets/src/components/GeneralSettings.js
@@ -3,12 +3,16 @@ import LayoutOption from "./LayoutOption";
 import SideCartLayout from '../../images/side-cart-layout.svg';
 import CenteredPopupLayout from '../../images/centered-popup-layout.svg';
 import SettingsSection from "sales-booster/src/components/settings/Panels/PanelSettings/SettingsSection";
+import ActionsHandler from "sales-booster/src/components/settings/Panels/PanelSettings/ActionsHandler";
 import RadioBox from "sales-booster/src/components/settings/Panels/PanelSettings/Fields/RadioBox";
 import ContentGroup from "./ContentGroup";
 
 const GeneralSettings = ({
+    onFormSave,
     formData,
     onFieldChange,
+    onFormReset,
+    buttonLoading
 }) => {
     const layoutContents = [
         {
@@ -58,6 +62,11 @@ const GeneralSettings = ({
                 options={ [ ...contentOptions ] }
                 title={ __( 'Cart Contents:', 'storegrowth-sales-booster' ) }
             />
+        <ActionsHandler
+          saveHandler={ () => onFormSave('general_settings')  }
+          resetHandler={ onFormReset }
+          loadingHandler={ buttonLoading }
+        />
         </SettingsSection>
     );
 }

--- a/includes/modules/fly-cart/assets/src/components/index.js
+++ b/includes/modules/fly-cart/assets/src/components/index.js
@@ -10,7 +10,7 @@ import PanelContainer from "sales-booster/src/components/settings/Panels/PanelCo
 import PanelRow from "sales-booster/src/components/settings/Panels/PanelRow";
 import PanelSettings from "sales-booster/src/components/settings/Panels/PanelSettings";
 import PanelPreview from "sales-booster/src/components/settings/Panels/PanelPreview";
-import ActionsHandler from "sales-booster/src/components/settings/Panels/PanelSettings/ActionsHandler";
+
 import { Fragment } from "react";
 import Preview from "./Preview";
 
@@ -143,9 +143,10 @@ function FlyCart( { navigate, useSearchParams } ) {
       title: __( 'General Setting', 'storegrowth-sales-booster' ),
       panel: <GeneralSettings
         formData={ formData }
-        onFormSave={ onFormSave }
+        onFormSave={ onFormSave}
         buttonLoading={ buttonLoading }
         onFieldChange={ onFieldChange }
+        onFormReset={onFormReset}
       />,
     },
     {
@@ -153,9 +154,10 @@ function FlyCart( { navigate, useSearchParams } ) {
       title: __( 'Design', 'storegrowth-sales-booster' ),
       panel: <DesignSettings
         formData={ formData }
-        onFormSave={ onFormSave }
+        onFormSave={ () => onFormSave('design') }
         onFieldChange={ onFieldChange }
         buttonLoading={ buttonLoading }
+        onFormReset={onFormReset}
       />,
     },
   ];
@@ -177,11 +179,6 @@ function FlyCart( { navigate, useSearchParams } ) {
             <Preview storeData={ formData } />
           </PanelPreview>
         </PanelRow>
-        <ActionsHandler
-          saveHandler={ onFormSave }
-          resetHandler={ onFormReset }
-          loadingHandler={ buttonLoading }
-        />
       </PanelContainer>
     </Fragment>
   );

--- a/includes/modules/fly-cart/includes/class-enqueue-script.php
+++ b/includes/modules/fly-cart/includes/class-enqueue-script.php
@@ -125,7 +125,6 @@ class Enqueue_Script {
 			}
 			.wfc-widget-sidebar {
 				background-color: {$widget_bg_color};
-				padding: 26px 0 !important;
 			}
 			.sgsb-cart-widget-buttons a {
 				background-color: {$wfc_btn_bgcolor};
@@ -150,32 +149,14 @@ class Enqueue_Script {
 	private function qc_side_cart_styles() {
 
 		$custom_css = '
-			.wfc-widget-sidebar {
-				width: 580px;
-				height: 100%;
-				position: fixed;
-				padding: 30px 0px;
-				top: 0;
-				right: 0;
-				z-index: 1001;
-				box-shadow: -2px 0px 9px 0px rgba(184,184,184,1);
-				transition: 0.5s;
-			}
-				.wfc-overlay {
-				position: fixed;
-				width: 100%;
-				height: 100%;
-				background-color: rgba(255, 255, 255, 0.83);
-				top: 0;
-				left: 0;
-				z-index: 1000;
-			}
-			.wfc-hide {
-				display: none
-			}
-			.wfc-slide{
-				right: -600px;
-			}';
+		.wfc-widget-sidebar {
+			top: 0;
+			right: 0;
+		}
+		.sgsb-widget-shopping-cart-content-wrapper{
+			width:540px;
+		}
+			';
 
 		wp_add_inline_style( 'sgsb-ffc-style', $custom_css );
 	}
@@ -185,13 +166,13 @@ class Enqueue_Script {
 	 */
 	private function frontend_widget_script() {
 		// Get checkout redirection data.
-		$qcart_settings        = get_option( 'sgsb_fly_cart_settings' );
-		$dir_checkout_settings = get_option( 'sgsb_direct_checkout_settings' );
-
+		$qcart_settings           = get_option( 'sgsb_fly_cart_settings' );
+		$dir_checkout_settings    = get_option( 'sgsb_direct_checkout_settings' );
+		$cart_layout_type         = sgsb_find_option_setting( $qcart_settings, 'layout', 'side' );
 		$is_add_to_qcart_redirect = sgsb_find_option_setting( $qcart_settings, 'enable_add_to_cart_redirect', true );
 		$checkout_redirect        = sgsb_find_option_setting( $dir_checkout_settings, 'checkout_redirect', 'legacy-checkout' );
 
-		$is_checkout_redirect = ( $checkout_redirect === 'quick-cart-checkout' );
+		$is_checkout_redirect = ( 'quick-cart-checkout' === $checkout_redirect );
 
 		wp_enqueue_script(
 			'wfc-script',
@@ -207,6 +188,7 @@ class Enqueue_Script {
 			array(
 				'checkoutRedirect'  => $is_checkout_redirect,
 				'quickCartRedirect' => $is_add_to_qcart_redirect,
+				'cartLayoutType'    => $cart_layout_type,
 				'ajaxUrl'           => admin_url( 'admin-ajax.php' ),
 				'nonce'             => wp_create_nonce( 'sgsb_frontend_ajax' ),
 				'isPro'             => is_plugin_active( 'storegrowth-sales-booster-pro/storegrowth-sales-booster-pro.php' ),

--- a/includes/modules/fly-cart/templates/cart-contents.php
+++ b/includes/modules/fly-cart/templates/cart-contents.php
@@ -46,42 +46,19 @@ $show_coupon          = sgsb_find_option_setting( $settings, 'show_coupon', true
 
 					<?php if ( $show_remove_icon || $show_product_image ) : ?>
 					<td class="product-thumbnail">
-						<?php if ( $show_remove_icon ) : ?>
-						<div class="product-remove">
 							<?php
-							echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-								'woocommerce_cart_item_remove_link',
-								sprintf(
-									'<a href="%s" class="sgsb-fly-cart-remove" aria-label="%s" data-product_id="%s" data-product_sku="%s">
-                                        <svg width="18" height="18" viewBox="0 0 20 20" fill="none">
-                                            <path
-                                                fill="#073B4C"
-                                                d="M8.33329 4.16667H11.6666C11.6666 3.72464 11.491 3.30072 11.1785 2.98816C10.8659 2.67559 10.442 2.5 9.99996 2.5C9.55793 2.5 9.13401 2.67559 8.82145 2.98816C8.50889 3.30072 8.33329 3.72464 8.33329 4.16667ZM7.08329 4.16667C7.08329 3.78364 7.15873 3.40437 7.30531 3.05051C7.45189 2.69664 7.66673 2.37511 7.93756 2.10427C8.2084 1.83343 8.52993 1.61859 8.8838 1.47202C9.23767 1.32544 9.61694 1.25 9.99996 1.25C10.383 1.25 10.7623 1.32544 11.1161 1.47202C11.47 1.61859 11.7915 1.83343 12.0624 2.10427C12.3332 2.37511 12.548 2.69664 12.6946 3.05051C12.8412 3.40437 12.9166 3.78364 12.9166 4.16667H17.7083C17.8741 4.16667 18.033 4.23251 18.1502 4.34973C18.2674 4.46694 18.3333 4.62591 18.3333 4.79167C18.3333 4.95743 18.2674 5.1164 18.1502 5.23361C18.033 5.35082 17.8741 5.41667 17.7083 5.41667H16.6083L15.6333 15.5092C15.5585 16.2825 15.1983 17.0002 14.623 17.5224C14.0477 18.0445 13.2985 18.3336 12.5216 18.3333H7.47829C6.70151 18.3334 5.95254 18.0442 5.37742 17.5221C4.80229 16.9999 4.44224 16.2823 4.36746 15.5092L3.39163 5.41667H2.29163C2.12587 5.41667 1.96689 5.35082 1.84968 5.23361C1.73247 5.1164 1.66663 4.95743 1.66663 4.79167C1.66663 4.62591 1.73247 4.46694 1.84968 4.34973C1.96689 4.23251 2.12587 4.16667 2.29163 4.16667H7.08329ZM8.74996 8.125C8.74996 7.95924 8.68411 7.80027 8.5669 7.68306C8.44969 7.56585 8.29072 7.5 8.12496 7.5C7.9592 7.5 7.80023 7.56585 7.68302 7.68306C7.56581 7.80027 7.49996 7.95924 7.49996 8.125V14.375C7.49996 14.5408 7.56581 14.6997 7.68302 14.8169C7.80023 14.9342 7.9592 15 8.12496 15C8.29072 15 8.44969 14.9342 8.5669 14.8169C8.68411 14.6997 8.74996 14.5408 8.74996 14.375V8.125ZM11.875 7.5C12.0407 7.5 12.1997 7.56585 12.3169 7.68306C12.4341 7.80027 12.5 7.95924 12.5 8.125V14.375C12.5 14.5408 12.4341 14.6997 12.3169 14.8169C12.1997 14.9342 12.0407 15 11.875 15C11.7092 15 11.5502 14.9342 11.433 14.8169C11.3158 14.6997 11.25 14.5408 11.25 14.375V8.125C11.25 7.95924 11.3158 7.80027 11.433 7.68306C11.5502 7.56585 11.7092 7.5 11.875 7.5ZM5.61163 15.3892C5.65657 15.853 5.87266 16.2835 6.21777 16.5968C6.56287 16.91 7.01225 17.0834 7.47829 17.0833H12.5216C12.9877 17.0834 13.437 16.91 13.7822 16.5968C14.1273 16.2835 14.3433 15.853 14.3883 15.3892L15.3533 5.41667H4.64663L5.61163 15.3892Z"
-                                            />
-                                        </svg>
-                                    </a>',
-									esc_url( wc_get_cart_remove_url( $cart_item_key ) . '&' . sgsb_fast_cart_get_query_string_for_http_ajax_referer() ),
-									esc_html__( 'Remove this item', 'storegrowth-sales-booster' ),
-									esc_attr( $product_id ),
-									esc_attr( $_product->get_sku() )
-								),
-								$cart_item_key
-							);
-							?>
-						</div>
-							<?php
-						endif;
 
-						if ( $show_product_image ) {
-							$thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
 
-							if ( ! $product_permalink ) {
-								echo $thumbnail; // phpcs:ignore
-							} else {
-								printf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $thumbnail ); // phpcs:ignore
+							if ( $show_product_image ) {
+								$thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
+
+								if ( ! $product_permalink ) {
+									echo $thumbnail; // phpcs:ignore
+								} else {
+									printf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $thumbnail ); // phpcs:ignore
+								}
 							}
-						}
-						?>
+							?>
 					</td>
 					<?php endif; ?>
 
@@ -142,14 +119,37 @@ $show_coupon          = sgsb_find_option_setting( $settings, 'show_coupon', true
 						?>
 					</td>
 					<?php endif; ?>
-
+					<?php if ( $show_remove_icon ) : ?>
+						<td class="product-remove">
+							<?php
+							echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								'woocommerce_cart_item_remove_link',
+								sprintf(
+									'<a href="%s" class="sgsb-fly-cart-remove" aria-label="%s" data-product_id="%s" data-product_sku="%s">
+                                        <svg width="18" height="18" viewBox="0 0 20 20" fill="none">
+                                            <path
+                                                fill="#073B4C"
+                                                d="M8.33329 4.16667H11.6666C11.6666 3.72464 11.491 3.30072 11.1785 2.98816C10.8659 2.67559 10.442 2.5 9.99996 2.5C9.55793 2.5 9.13401 2.67559 8.82145 2.98816C8.50889 3.30072 8.33329 3.72464 8.33329 4.16667ZM7.08329 4.16667C7.08329 3.78364 7.15873 3.40437 7.30531 3.05051C7.45189 2.69664 7.66673 2.37511 7.93756 2.10427C8.2084 1.83343 8.52993 1.61859 8.8838 1.47202C9.23767 1.32544 9.61694 1.25 9.99996 1.25C10.383 1.25 10.7623 1.32544 11.1161 1.47202C11.47 1.61859 11.7915 1.83343 12.0624 2.10427C12.3332 2.37511 12.548 2.69664 12.6946 3.05051C12.8412 3.40437 12.9166 3.78364 12.9166 4.16667H17.7083C17.8741 4.16667 18.033 4.23251 18.1502 4.34973C18.2674 4.46694 18.3333 4.62591 18.3333 4.79167C18.3333 4.95743 18.2674 5.1164 18.1502 5.23361C18.033 5.35082 17.8741 5.41667 17.7083 5.41667H16.6083L15.6333 15.5092C15.5585 16.2825 15.1983 17.0002 14.623 17.5224C14.0477 18.0445 13.2985 18.3336 12.5216 18.3333H7.47829C6.70151 18.3334 5.95254 18.0442 5.37742 17.5221C4.80229 16.9999 4.44224 16.2823 4.36746 15.5092L3.39163 5.41667H2.29163C2.12587 5.41667 1.96689 5.35082 1.84968 5.23361C1.73247 5.1164 1.66663 4.95743 1.66663 4.79167C1.66663 4.62591 1.73247 4.46694 1.84968 4.34973C1.96689 4.23251 2.12587 4.16667 2.29163 4.16667H7.08329ZM8.74996 8.125C8.74996 7.95924 8.68411 7.80027 8.5669 7.68306C8.44969 7.56585 8.29072 7.5 8.12496 7.5C7.9592 7.5 7.80023 7.56585 7.68302 7.68306C7.56581 7.80027 7.49996 7.95924 7.49996 8.125V14.375C7.49996 14.5408 7.56581 14.6997 7.68302 14.8169C7.80023 14.9342 7.9592 15 8.12496 15C8.29072 15 8.44969 14.9342 8.5669 14.8169C8.68411 14.6997 8.74996 14.5408 8.74996 14.375V8.125ZM11.875 7.5C12.0407 7.5 12.1997 7.56585 12.3169 7.68306C12.4341 7.80027 12.5 7.95924 12.5 8.125V14.375C12.5 14.5408 12.4341 14.6997 12.3169 14.8169C12.1997 14.9342 12.0407 15 11.875 15C11.7092 15 11.5502 14.9342 11.433 14.8169C11.3158 14.6997 11.25 14.5408 11.25 14.375V8.125C11.25 7.95924 11.3158 7.80027 11.433 7.68306C11.5502 7.56585 11.7092 7.5 11.875 7.5ZM5.61163 15.3892C5.65657 15.853 5.87266 16.2835 6.21777 16.5968C6.56287 16.91 7.01225 17.0834 7.47829 17.0833H12.5216C12.9877 17.0834 13.437 16.91 13.7822 16.5968C14.1273 16.2835 14.3433 15.853 14.3883 15.3892L15.3533 5.41667H4.64663L5.61163 15.3892Z"
+                                            />
+                                        </svg>
+                                    </a>',
+									esc_url( wc_get_cart_remove_url( $cart_item_key ) . '&' . sgsb_fast_cart_get_query_string_for_http_ajax_referer() ),
+									esc_html__( 'Remove this item', 'storegrowth-sales-booster' ),
+									esc_attr( $product_id ),
+									esc_attr( $_product->get_sku() )
+								),
+								$cart_item_key
+							);
+							?>
+						</td>
+						<?php endif; ?>
 				</tr>
 				<?php
 			}
 		}
 		?>
 
-		<?php do_action( 'woocommerce_cart_contents' ); ?>
+				<?php do_action( 'woocommerce_cart_contents' ); ?>
 
 		<tr>
 			<td colspan="6" class="actions">
@@ -163,26 +163,26 @@ $show_coupon          = sgsb_find_option_setting( $settings, 'show_coupon', true
 			</td>
 		</tr>
 
-		<?php do_action( 'woocommerce_after_cart_contents' ); ?>
+				<?php do_action( 'woocommerce_after_cart_contents' ); ?>
 		</tbody>
 	</table>
-	<?php do_action( 'woocommerce_after_cart_table' ); ?>
+				<?php do_action( 'woocommerce_after_cart_table' ); ?>
 </form>
-<?php do_action( 'sgsb_woocommerce_before_cart_collaterals' ); ?>
+				<?php do_action( 'sgsb_woocommerce_before_cart_collaterals' ); ?>
 
 <div class="sgsb-cart-collaterals cart-collaterals">
-	<?php
-	/**
-	 * Cart collaterals hook.
-	 *
-	 * @since 1.0.0
-	 */
-	if ( $show_coupon && wc_coupons_enabled() ) {
-		do_action( 'storegrowth_sb_quick_cart_coupon' );
-	}
+				<?php
+				/**
+				 * Cart collaterals hook.
+				 *
+				 * @since 1.0.0
+				 */
+				if ( $show_coupon && wc_coupons_enabled() ) {
+					do_action( 'storegrowth_sb_quick_cart_coupon' );
+				}
 
-	do_action( 'woocommerce_cart_collaterals' );
-	?>
+				do_action( 'woocommerce_cart_collaterals' );
+				?>
 </div>
 
-<?php do_action( 'woocommerce_after_cart' ); ?>
+				<?php do_action( 'woocommerce_after_cart' ); ?>

--- a/includes/modules/fly-cart/templates/fly-cart.php
+++ b/includes/modules/fly-cart/templates/fly-cart.php
@@ -24,7 +24,7 @@ $action_btn_active_bg = sgsb_find_option_setting( $settings, 'buttons_bg_color',
 				fill='none'
 				class='radio-icon'
 				viewBox='0 0 100 100'
-				style='width: 55px; height: 50px; padding: 16px; border-radius: 10px; background: <?php echo esc_attr( $action_btn_active_bg ); ?>;'
+				style='  border-radius: 10px; background: <?php echo esc_attr( $action_btn_active_bg ); ?>;'
 			>
 				<g>
 					<polygon
@@ -68,7 +68,7 @@ $action_btn_active_bg = sgsb_find_option_setting( $settings, 'buttons_bg_color',
 				fill='none'
 				class='radio-icon'
 				viewBox='0 0 100 100'
-				style='width: 55px; height: 50px; padding: 16px; border-radius: 10px; background: <?php echo esc_attr( $action_btn_active_bg ); ?>;'
+				style='border-radius: 10px; background: <?php echo esc_attr( $action_btn_active_bg ); ?>;'
 			>
 				<g>
 					<path
@@ -89,7 +89,7 @@ $action_btn_active_bg = sgsb_find_option_setting( $settings, 'buttons_bg_color',
 				fill='none'
 				class='radio-icon'
 				viewBox='0 0 100 100'
-				style='width: 55px; height: 50px; padding: 16px; border-radius: 10px; background: <?php echo esc_attr( $action_btn_active_bg ); ?>;'
+				style='  border-radius: 10px; background: <?php echo esc_attr( $action_btn_active_bg ); ?>;'
 			>
 				<g>
 					<path
@@ -110,7 +110,7 @@ $action_btn_active_bg = sgsb_find_option_setting( $settings, 'buttons_bg_color',
 				fill='none'
 				class='radio-icon'
 				viewBox='0 0 100 100'
-				style='width: 55px; height: 50px; padding: 16px; border-radius: 10px; background: <?php echo esc_attr( $action_btn_active_bg ); ?>;'
+				style='  border-radius: 10px; background: <?php echo esc_attr( $action_btn_active_bg ); ?>;'
 			>
 				<g>
 					<path


### PR DESCRIPTION
In this commit the quick cart design is fixed and now compatible and fixed

- [x] Fixed the broken style of quick cart in FSE
- [x] Fixed the fly cart shake issue in FSE
- [x] Added styling to the notice in the cart
- [x] Added enhancement of styling in the cart content height to be calculated Dynamically
- [x] Restructured the Quick cart stylings

In this patch the content height is being Dynamically being calculated according to the inner height.
<img width="1431" alt="image" src="https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/586e3ec1-a758-4dda-a81e-6105ad6607ec">

This fix is linked to this PR of the Pro version: [#30](https://github.com/Invizo/storegrowth-sales-booster-pro/pull/30)
Theme 2023
resolves: #297