### PR TITLE
enhance: make-module-search-case-insensitive-&-add-prompt-on-qcart-coupon-preview

### DIFF
--- a/assets/src/admin.scss
+++ b/assets/src/admin.scss
@@ -2570,6 +2570,50 @@ End Settings Sidebar
         display: block;
         position: sticky;
         margin-left: 32px;
+
+        .product-coupon {
+          position: relative;
+
+          .pro-content-overlay {
+            top: -3px;
+            left: -13px;
+            width: 105%;
+            height: 120%;
+            z-index: 9999;
+            display: none;
+            border-radius: 5px;
+            position: absolute;
+            align-items: center;
+            background: #00000080;
+            justify-content: center;
+
+            .upgrade-button {
+              gap: 10px;
+              color: #fff;
+              font-size: 13px;
+              font-weight: 600;
+              padding: 9px 15px;
+              border-radius: 5px;
+              align-items: center;
+              background: #FFAC27;
+              display: inline-flex;
+
+              .overlay-btn-crown {
+                svg {
+                  path {
+                    fill: #fff;
+                  }
+                }
+              }
+            }
+          }
+
+          &:hover {
+            .pro-content-overlay {
+              display: flex;
+            }
+          }
+        }
       }
     }
 

--- a/assets/src/components/modules/ModuleSearch.js
+++ b/assets/src/components/modules/ModuleSearch.js
@@ -7,9 +7,7 @@ function ModuleSearch({onChange}) {
 
     const [isActive, setIsActive] = useState(false);
 
-    const handleSearchClass = () => {
-        setIsActive((prevIsActive) => !prevIsActive);
-    }
+    const handleSearchClass = () => setIsActive((prevIsActive) => !prevIsActive);
 
     return (
         <div className={isActive ? 'search-bar active' : 'search-bar'}>

--- a/assets/src/components/modules/Modules.js
+++ b/assets/src/components/modules/Modules.js
@@ -163,7 +163,7 @@ function Modules() {
     return (
       <>
         {modules
-          .filter((module) => module.name.toLowerCase().includes(searchModule))
+          .filter((module) => module.name.toLowerCase().includes(searchModule.toLowerCase()))
           .filter((module) => (filterActiveModules ? module.status : true)) // Filter based on the filterActiveModules state
           .slice(minValue, maxValue)
           .map((module) => (

--- a/includes/modules/fly-cart/assets/src/components/Preview.js
+++ b/includes/modules/fly-cart/assets/src/components/Preview.js
@@ -4,6 +4,7 @@ import { Image, Typography } from 'antd';
 import PreviewImg from '../../images/qcart-preview.svg';
 import CartIcon from "./CartIcon";
 import UpgradeCrown from "sales-booster/src/components/settings/Panels/PanelSettings/UpgradeCrown";
+import UpgradeOverlay from "sales-booster/src/components/settings/Panels/PanelSettings/UpgradeOverlay";
 
 const { Title } = Typography;
 
@@ -364,6 +365,7 @@ const Preview = ( { storeData } ) => {
                                             { __( 'Apply Now', 'storegrowth-sales-booster' ) }
                                         </div>
                                     </div>
+                                    { !sgsbAdmin.isPro && <UpgradeOverlay /> }
                                 </div>
                             ) }
                             <div className='cart_totals '>


### PR DESCRIPTION
### Make module search case insensitive & add prompt on qcart coupon preview

-- Description --

Currently, we have case case-sensitive search on the module search bar which is only applicable to the exact module name. When user searched their module name using the module title & they got an empty result which is not expected. After this enhancement, we can search by exact module name. Also, in qcart modules coupon preview has no prompt msg. Right now we add a prompt layer on the free version.

Issue: #287 