### PR TITLE
fix(quick-cart): Quick cart redirection , icon layout select field la…

### DIFF
--- a/assets/src/admin.scss
+++ b/assets/src/admin.scss
@@ -1577,6 +1577,7 @@ End Settings Sidebar
       }
 
       .dashboard-pricing-page {
+
         .dashboad-content,
         .sg_pricing_table {
           margin-top: 20px;
@@ -1618,6 +1619,7 @@ End Settings Sidebar
       }
 
       .dashboard-pricing-page {
+
         .dashboad-content,
         .sg_pricing_table {
           margin-top: 20px;
@@ -2297,10 +2299,22 @@ End Settings Sidebar
                     }
                   }
                 }
-
+                &.radio-icon-field{
+                  &.quick-icon-layout {
+                    @media (max-width: 1440px) {
+                      grid-template-rows: repeat(1, auto);
+                    }
+                }
+              }
                 &.radio-img-field {
                   height: 100%;
                   margin-top: 20px;
+
+                  &.quick-cart-layout {
+                    @media (max-width: 1440px) {
+                      grid-template-rows: repeat(1, auto);
+                    }
+                  }
 
                   label.ant-radio-button-wrapper {
                     color: #073B4C;
@@ -2398,7 +2412,7 @@ End Settings Sidebar
 
               span {
                 @media (max-width: 1440px) {
-                   display: none;
+                  display: none;
                 }
               }
 

--- a/includes/modules/fly-cart/assets/js/wfc-script.js
+++ b/includes/modules/fly-cart/assets/js/wfc-script.js
@@ -166,7 +166,7 @@
           event.preventDefault();
           const productId = jQuery(event?.target).data("id");
           jQuery.ajax({
-            url: wc_add_to_cart_params.ajax_url,
+            url: sgsbFrontend.ajaxUrl,
             type: "POST",
             data: {
               action: "woocommerce_add_to_cart",

--- a/includes/modules/fly-cart/assets/src/components/DesignSettings.js
+++ b/includes/modules/fly-cart/assets/src/components/DesignSettings.js
@@ -45,6 +45,7 @@ const DesignSettings = ({
                 name={ `icon_name` }
                 options={ [ ...iconOptions ] }
                 changeHandler={ onFieldChange }
+                classes={ `radio-icon-field quick-icon-layout` }
                 fieldValue={ formData.icon_name }
                 title={ __( `Cart Icon`, 'storegrowth-sales-booster' ) }
             />

--- a/includes/modules/fly-cart/assets/src/components/GeneralSettings.js
+++ b/includes/modules/fly-cart/assets/src/components/GeneralSettings.js
@@ -50,7 +50,7 @@ const GeneralSettings = ({
             <RadioBox
                 name={ `layout` }
                 fieldWidth={ true }
-                classes={ `radio-img-field` }
+                classes={ `radio-img-field quick-cart-layout` }
                 fieldValue={ formData.layout }
                 changeHandler={ onFieldChange }
                 options={ [ ...layoutOptions ] }


### PR DESCRIPTION
…yout

In this commit the quick cart icon selection and the layout selection is fixed.

fixed: 
<img width="493" alt="image" src="https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/aa7d6f7b-507e-43e7-9ec1-7b583fb8071a">
<img width="527" alt="image" src="https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/1b70b046-bcb7-408a-b682-9f9496ec2d48">

- [x] Buy Now Quick cart redirection.

resolves: Quick cart: quick cart redirection and layout design fix. #309