### PR TITLE
fix: upsell-order-bump-duplication-error-handling-issue

### DIFF
--- a/includes/modules/upsell-order-bump/assets/src/components/BasicInfo.js
+++ b/includes/modules/upsell-order-bump/assets/src/components/BasicInfo.js
@@ -13,7 +13,7 @@ import SelectBox from "sales-booster/src/components/settings/Panels/PanelSetting
 import OfferField from "./OfferField";
 
 
-const BasicInfo = ({ clearErrors, triggerBumpUpdate }) => {
+const BasicInfo = ({ clearErrors }) => {
   const { setCreateFromData } = useDispatch("sgsb_order_bump");
   const { createBumpData } = useSelect((select) => ({
     createBumpData: select("sgsb_order_bump").getCreateFromData(),
@@ -88,9 +88,6 @@ const BasicInfo = ({ clearErrors, triggerBumpUpdate }) => {
         });
       }
     }
-
-    // Trigger bump update need.
-    if (key === "offer_amount" || key === "offer_type") triggerBumpUpdate(true);
 
     if (key === "offer_product") {
       setCreateFromData({

--- a/includes/modules/upsell-order-bump/assets/src/components/CreateBump.js
+++ b/includes/modules/upsell-order-bump/assets/src/components/CreateBump.js
@@ -18,7 +18,6 @@ function CreateBump({navigate, useParams, useSearchParams}) {
   const [allBumpsData, setallBumpsData] = useState([]);
   const [duplicateDataError, setDuplicateDataError] = useState({});
   const [isModalVisible, setIsModalVisible] = useState(false);
-  const [bumpUpdate, setBumpUpdate] = useState(false);
   const { setPageLoading } = useDispatch( 'sgsb' );
   const [buttonLoading, setButtonLoading] = useState(false);
   const { setCreateFromData, resetCreateFromData } = useDispatch( 'sgsb_order_bump' );
@@ -213,36 +212,33 @@ function CreateBump({navigate, useParams, useSearchParams}) {
                 setDuplicateDataError(duplicateErrs);
                 return false;
             }
-
-            if ( !Boolean( bumpUpdate ) ) {
-                setDuplicateDataError(duplicateErrs);
-                return false;
-            }
         }
     }
-    
-    setButtonLoading( true );
-    const bumpDataParsedToEntities = convertBumpItemTextDatasToHtmlEntities(createBumpData);
-    let $ = jQuery;
-    $.post( bump_save_url.ajax_url, { 
-      'action'    : 'bump_create',
-      'data'      : bumpDataParsedToEntities,
-      '_ajax_nonce' : bump_save_url.ajd_nonce
 
-      }, function ( data ) {
-      setCreateFromData( {
-        ...bumpDataParsedToEntities,
-        offer_product_id: data
-      } );
-      setButtonLoading( false );
+    // Check if bump order not duplicate then saved.
+    if ( ! ( isDuplicateCatsFound || isDuplicateProductsFound ) ) {
+      setButtonLoading( true );
+      const bumpDataParsedToEntities = convertBumpItemTextDatasToHtmlEntities(createBumpData);
+      let $ = jQuery;
+      $.post( bump_save_url.ajax_url, {
+          'action'    : 'bump_create',
+          'data'      : bumpDataParsedToEntities,
+          '_ajax_nonce' : bump_save_url.ajd_nonce
+        }, function ( data ) {
+        setCreateFromData( {
+                ...bumpDataParsedToEntities,
+                offer_product_id: data
+            } );
+        setButtonLoading( false );
 
-      notification['success']({
-        message     : 'Order Bump Creation',
-        description : 'Data for order bump creation saved successfully',
+        notification['success']({
+                message     : 'Order Bump Creation',
+                description : 'Data for order bump creation saved successfully',
+            });
+
+        navigate( "/upsell-order-bump" );
       });
-
-      navigate( "/upsell-order-bump" );
-    });
+    }
 
   }
 
@@ -262,12 +258,12 @@ function CreateBump({navigate, useParams, useSearchParams}) {
     {
       key: 'basic',
       title: __( 'Basic Information', 'storegrowth-sales-booster' ),
-      panel: <BasicInfo clearErrors={ clearErrors } triggerBumpUpdate={ setBumpUpdate } />,
+      panel: <BasicInfo clearErrors={ clearErrors } />,
     },
     {
       key: 'design',
       title: __( 'Design', 'storegrowth-sales-booster' ),
-      panel: <DesignSection triggerBumpUpdate={ setBumpUpdate } />,
+      panel: <DesignSection />,
     },
   ];
 

--- a/includes/modules/upsell-order-bump/assets/src/components/DesignSection.js
+++ b/includes/modules/upsell-order-bump/assets/src/components/DesignSection.js
@@ -3,17 +3,17 @@ import ContentSection from "./appearance/ContentSection";
 import TemplateSection from "./appearance/TemplateSection";
 import ExpandPanels from "sales-booster/src/components/settings/Panels/PanelSettings/ExpandPanels";
 
-const DesignSection = ( { triggerBumpUpdate } ) => {
+const DesignSection = () => {
     const panels = [
         {
             key: 1,
             label: __( 'Template Section', 'storegrowth-sales-booster' ),
-            children: <TemplateSection triggerBumpUpdate={ triggerBumpUpdate } />,
+            children: <TemplateSection />,
         },
         {
             key: 2,
             label: __( 'Content Section', 'storegrowth-sales-booster' ),
-            children: <ContentSection triggerBumpUpdate={ triggerBumpUpdate } />,
+            children: <ContentSection />,
         }
     ];
 

--- a/includes/modules/upsell-order-bump/assets/src/components/appearance/ContentSection.js
+++ b/includes/modules/upsell-order-bump/assets/src/components/appearance/ContentSection.js
@@ -3,7 +3,7 @@ import { Fragment } from "react";
 import { __ } from "@wordpress/i18n";
 import { useDispatch, useSelect } from '@wordpress/data';
 
-const ContentSection = ( { triggerBumpUpdate } ) => {
+const ContentSection = () => {
     const { setCreateFromData } = useDispatch( 'sgsb_order_bump' );
 
     const { createBumpData } = useSelect( ( select ) => ( {
@@ -11,7 +11,6 @@ const ContentSection = ( { triggerBumpUpdate } ) => {
     } ) );
 
     const onFieldChange = ( key, value ) => {
-        triggerBumpUpdate( true );
         setCreateFromData( {
             ...createBumpData,
             [ key ]: value

--- a/includes/modules/upsell-order-bump/assets/src/components/appearance/TemplateSection.js
+++ b/includes/modules/upsell-order-bump/assets/src/components/appearance/TemplateSection.js
@@ -7,7 +7,7 @@ import ColourPicker from "sales-booster/src/components/settings/Panels/PanelSett
 import SettingsSection from "sales-booster/src/components/settings/Panels/PanelSettings/SettingsSection";
 import {Fragment} from "react";
 
-const TemplateSection = ( { triggerBumpUpdate } ) => {
+const TemplateSection = () => {
     const { setCreateFromData } = useDispatch( 'sgsb_order_bump' );
 
     const { createBumpData } = useSelect( ( select ) => ( {
@@ -15,7 +15,6 @@ const TemplateSection = ( { triggerBumpUpdate } ) => {
     } ) );
 
     const onFieldChange = ( key, value ) => {
-        triggerBumpUpdate( true );
         setCreateFromData( {
             ...createBumpData,
             [ key ]: value


### PR DESCRIPTION
### Upsell order bump validation issue when creating a duplicate bump.

-- Description --
Currently, upsell order bump duplication error msg not handling perfectly. When we edit an order bump and hit save button it returns duplication error. But when we visit design panel and hit save button it returns error but behind the scene it saved value. Currently, we removed validation from bump editing panel & validate bump when a new bump create. Now, business logic is, if target bumps cat or product id matched then throw an error for new creation.

SS: [Link](https://prnt.sc/FZJKUIcnf1f7)

Issue: #287 