### PR TITLE
fix: direct-checkout-button-placement-&-ui-broken-issue

### DIFF
--- a/assets/src/admin.scss
+++ b/assets/src/admin.scss
@@ -2305,8 +2305,8 @@ End Settings Sidebar
                     @media (max-width: 1440px) {
                       grid-template-rows: repeat(1, auto);
                     }
+                  }
                 }
-              }
                 &.radio-img-field {
                   height: 100%;
                   margin-top: 20px;

--- a/includes/modules/direct-checkout/assets/src/components/DirectCheckout.js
+++ b/includes/modules/direct-checkout/assets/src/components/DirectCheckout.js
@@ -41,7 +41,7 @@ function DirectCheckout({ outlet: Outlet }) {
   }, []);
   return (
     <Form {...layout}>
-        <Outlet />
+      <Outlet />
     </Form>
   );
 }

--- a/includes/modules/direct-checkout/includes/class-common-hooks.php
+++ b/includes/modules/direct-checkout/includes/class-common-hooks.php
@@ -198,7 +198,6 @@ class Common_Hooks {
 	private function display_buy_now_button() {
 		global $product;
 
-		// ob_start();
 		$product_id                    = get_the_ID();
 		$direct_checkout_button_layout = get_post_meta( $product_id, '_sgsb_direct_checkout_button_layout', true );
 		$settings                      = get_option( 'sgsb_direct_checkout_settings' );
@@ -212,10 +211,5 @@ class Common_Hooks {
 				include __DIR__ . '/../templates/add-cart-with-buy-now.php';
 			}
 		}
-
-		// $output_buffer = ob_get_contents();
-		// ob_end_clean();
-		//
-		// return $output_buffer;
 	}
 }

--- a/includes/modules/direct-checkout/includes/class-common-hooks.php
+++ b/includes/modules/direct-checkout/includes/class-common-hooks.php
@@ -37,7 +37,7 @@ class Common_Hooks {
 		$buy_now_button_setting = sgsb_find_option_setting( $settings, 'buy_now_button_setting', 'cart-with-buy-now' );
 		if ( 'cart-with-buy-now' === $buy_now_button_setting || 'specific-buy-now' === $buy_now_button_setting ) {
 			// Show direct checkout button on shop loop item and product page.
-			add_action( 'woocommerce_after_shop_loop_item', array( $this, 'show_direct_checkout_button_shop' ), 15 );
+			add_filter( 'woocommerce_loop_add_to_cart_link', array( $this, 'show_direct_checkout_button_shop' ), 15 );
 			add_action( 'woocommerce_after_add_to_cart_button', array( $this, 'show_direct_checkout_button_product' ) );
 
 			if ( 'specific-buy-now' === $buy_now_button_setting ) {
@@ -60,12 +60,25 @@ class Common_Hooks {
 	}
 
 	/**
-	 * Hook for WooCommerce after shop loop item.
+	 * Hook for WooCommerce loop add to cart link.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $add_to_cart Add to cart link.
+	 *
+	 * @return string
 	 */
-	public function show_direct_checkout_button_shop() {
+	public function show_direct_checkout_button_shop( $add_to_cart ) {
 		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) ) {
+			ob_start();
 			$this->display_buy_now_button();
+			$buy_now_button = ob_get_contents();
+			ob_end_clean();
+
+			$add_to_cart .= $buy_now_button;
 		}
+
+		return $add_to_cart;
 	}
 
 	/**
@@ -178,12 +191,14 @@ class Common_Hooks {
 		}
 		return $template;
 	}
-		/**
-		 * Function to display the Buy Now button.
-		 */
+
+	/**
+	 * Function to display the Buy Now button.
+	 */
 	private function display_buy_now_button() {
 		global $product;
 
+		// ob_start();
 		$product_id                    = get_the_ID();
 		$direct_checkout_button_layout = get_post_meta( $product_id, '_sgsb_direct_checkout_button_layout', true );
 		$settings                      = get_option( 'sgsb_direct_checkout_settings' );
@@ -197,5 +212,10 @@ class Common_Hooks {
 				include __DIR__ . '/../templates/add-cart-with-buy-now.php';
 			}
 		}
+
+		// $output_buffer = ob_get_contents();
+		// ob_end_clean();
+		//
+		// return $output_buffer;
 	}
 }

--- a/includes/modules/direct-checkout/includes/class-enqueue-script.php
+++ b/includes/modules/direct-checkout/includes/class-enqueue-script.php
@@ -99,9 +99,9 @@ class Enqueue_Script {
 		);
 	}
 
-		/**
-		 * All inline styles
-		 */
+	/**
+	 * All inline styles
+	 */
 	private function dc_button_inline_styles() {
 		// Get style options.
 		$settings             = get_option( 'sgsb_direct_checkout_settings' );
@@ -110,6 +110,11 @@ class Enqueue_Script {
 		$font_size            = sgsb_find_option_setting( $settings, 'font_size', '16' );
 		$button_border_radius = sgsb_find_option_setting( $settings, 'button_border_radius', '5' );
 
+		$theme             = wp_get_theme();
+        $is_avada_theme    = ! empty( $theme->name ) ? $theme->name === 'Avada' : false;
+        $is_ocean_wp_theme = ! empty( $theme->name ) ? $theme->name === 'OceanWP' : false;
+		$button_margin     = $is_ocean_wp_theme ? '20px 0 0' : '0 0 10px 10px';
+
 		$custom_css = "
 		.button.product_type_simple.sgsb_buy_now_button, 
 		.button.product_type_simple.sgsb_buy_now_button_product_page {
@@ -117,10 +122,33 @@ class Enqueue_Script {
 			border-radius: {$button_border_radius}px;
 			font-size: {$font_size}px !important;
 			color: {$text_color} !important;
-			margin-bottom: 10px !important;
+			margin: {$button_margin} !important;
+		} ";
+
+		if ( $is_avada_theme ) {
+			$custom_css .= '
+			.products .product-buttons-container {
+			    display: flex;
+                flex-wrap: wrap;
+                align-items: center;
+			}
+			.product_type_simple.add_to_cart_button {
+			    order: 1;
+			}
+            .button.product_type_simple.sgsb_buy_now_button {
+                order: 3;
+                padding: 10px 20px;
+                margin: 12px 0 0 0 !important;
+            }
+            .button.product_type_simple.sgsb_buy_now_button::before {
+                content: "";
+            }
+            .show_details_button {
+                order: 2;
+                margin-left: auto;
+            }
+            ';
 		}
-	
-			";
 
 		wp_add_inline_style( 'sgsb-button-style', $custom_css );
 	}

--- a/includes/modules/floating-notification-bar/assets/js/sgsb-pd-banner-bar-remove.js
+++ b/includes/modules/floating-notification-bar/assets/js/sgsb-pd-banner-bar-remove.js
@@ -11,7 +11,7 @@
     let button_view = sgsb_fnb_data.button_view;
     let countdown_start_date = sgsb_fnb_data.countdown_start_date;
     let countdown_end_date = sgsb_fnb_data.countdown_end_date;
-    let coupon_code = sgsb_fnb_data.cupon_code.toUpperCase();
+    let coupon_code = sgsb_fnb_data?.cupon_code?.toUpperCase();
     let body_top_padding = parseInt(banner_height) + 10;
     const fn_banner_hidden_time = localStorage.getItem("fn_banner_hidden_time");
 

--- a/includes/modules/progressive-discount-banner/assets/js/sgsb-pd-banner-bar-remove.js
+++ b/includes/modules/progressive-discount-banner/assets/js/sgsb-pd-banner-bar-remove.js
@@ -66,9 +66,9 @@
     $(document).ready(function () {
       const isMobile = isMobileDevice();
       const shouldHideMobile =
-        banner_device_view.includes("banner-show-mobile") && isMobile;
+        banner_device_view?.includes("banner-show-mobile") && isMobile;
       const shouldHideDesktop =
-        banner_device_view.includes("banner-show-desktop") && !isMobile;
+        banner_device_view?.includes("banner-show-desktop") && !isMobile;
 
       if (!shouldHideMobile && !shouldHideDesktop) {
         $(".sgsb-pd-banner-bar-wrapper").remove();


### PR DESCRIPTION
-- Description --
Currently, we are getting some ui broken issue on avada & ocean-wp theme. Also, we have some inconsistencies for buy now button placement on shop page.

1. Ensure buy now button placement properly on shop page.
2. Fix direct checkout buttons ui broken issue on avada theme.
3. Fix direct checkout buttons ui broken issue on OceanWP theme.
4. Fix console issues on free shipping bar.

Images: [Link](https://tinyurl.com/yt4jcpbt) | [Link](https://tinyurl.com/ylmcpx98) | [Link](https://tinyurl.com/ynpx5a6s)

Issue: #317