### PR TITLE
fix(admin): conditional promotion

### DIFF
--- a/assets/src/components/dashboard/Promotion.js
+++ b/assets/src/components/dashboard/Promotion.js
@@ -2,10 +2,11 @@ import React from "react";
 import PremiumBox from "./PremiumBox";
 import Gaurantee from "./Gaurantee";
 const Promotion = () => {
+  const isPro = !sgsbAdmin?.isPro;
   const pricingPath = window.location.hash === "#/dashboard/pricing";
   return (
     <div className="sgsb-promotion-block">
-      {!pricingPath && <PremiumBox />}
+      {(!pricingPath && isPro) && <PremiumBox />}
       <Gaurantee />
     </div>
   );


### PR DESCRIPTION
Description
When the pro version is activated the promotion will be removed too.

<img width="1061" alt="image" src="https://github.com/Invizo/storegrowth-sales-booster/assets/65698588/2314f963-4054-4448-a4d6-604e076603e2">

resolves: Pro teaser removal  #332