### PR TITLE
🎯 fix: Buy now button missing for stock out products

### DIFF
--- a/Includes/Modules/DirectCheckout/Includes/CommonHooks.php
+++ b/Includes/Modules/DirectCheckout/Includes/CommonHooks.php
@@ -246,7 +246,7 @@ class CommonHooks {
 		( 'cart-with-buy-now' === $direct_checkout_button_layout && 'specific-buy-now' === $buy_now_button_setting )
 		|| 'cart-with-buy-now' === $buy_now_button_setting
 		) {
-			if ( 'simple' === $product->get_type() && $product->is_purchasable() && $product->is_in_stock() ) {
+			if ( 'simple' === $product->get_type() && $product->is_purchasable() ) {
 				include __DIR__ . '/../templates/buy-now-button-template.php';
 			}
 		}

--- a/Includes/Modules/DirectCheckout/assets/css/sgsb-dc-style.css
+++ b/Includes/Modules/DirectCheckout/assets/css/sgsb-dc-style.css
@@ -18,3 +18,8 @@ form.cart .sgsb_buy_now_button_product_page {
   padding: 10px 20px;
   margin-left: 20px !important;
 }
+
+.sgsb_buy_now_button_disabled {
+    opacity: 0.7;
+    cursor: not-allowed !important;
+}

--- a/Includes/Modules/DirectCheckout/assets/js/sgsb-dc-script.js
+++ b/Includes/Modules/DirectCheckout/assets/js/sgsb-dc-script.js
@@ -9,7 +9,11 @@
     handleProductDirectCheckout: function( event ) {
       event.stopPropagation();
       event.preventDefault();
-  
+
+        if ( event?.target?.classList.contains('sgsb_buy_now_button_disabled') ) {
+            return;
+        }
+
       // Check quick cart checkout availability first.
       if ( sgsbDcFrontend?.isPro && sgsbDcFrontend?.isQuickCartCheckout ) return;
       let productId = jQuery( event?.target ).data( 'id' ),
@@ -51,6 +55,10 @@ const sgsbDirectChecoutQuick = {
   handleProductDirectCheckout: function( event ) {
     event.stopPropagation();
     event.preventDefault();
+
+    if ( event?.target?.classList.contains('sgsb_buy_now_button_disabled') ) {
+      return;
+    }
 
     // Check quick cart checkout availability first.
     let productId = jQuery( event?.target ).data( 'id' ),

--- a/Includes/Modules/DirectCheckout/templates/buy-now-button-template.php
+++ b/Includes/Modules/DirectCheckout/templates/buy-now-button-template.php
@@ -11,6 +11,7 @@ $product_type         = $product->get_type();
 $settings             = get_option( 'sgsb_direct_checkout_settings' );
 $buy_now_button_label = sgsb_find_option_setting( $settings, 'buy_now_button_label', 'Buy Now' );
 $product_page         = is_product() ? '_product_page' : '';
+$stock_class_name     = $product->is_in_stock() ? ' ' : 'sgsb_buy_now_button_disabled';
 	$classes          = implode(
 		' ',
 		array_filter(
@@ -18,6 +19,7 @@ $product_page         = is_product() ? '_product_page' : '';
 				'button',
 				'product_type_' . $product_type,
 				'sgsb_buy_now_button' . $product_page,
+                $stock_class_name,
 			)
 		)
 	);

--- a/Includes/Modules/FlyCart/assets/js/wfc-script.js
+++ b/Includes/Modules/FlyCart/assets/js/wfc-script.js
@@ -129,6 +129,11 @@
         "click",
         function (event) {
           event.preventDefault();
+
+          if ( event?.target?.classList.contains('sgsb_buy_now_button_disabled') ) {
+            return;
+          }
+
           const productId = jQuery(event?.target).data("id");
           jQuery.ajax({
             url: sgsbFrontend.ajaxUrl,


### PR DESCRIPTION
* Closes: https://github.com/getdokan/storegrowth-sales-booster-pro/issues/70

* Related Pro PR: https://github.com/getdokan/storegrowth-sales-booster-pro/pull/86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The "Buy Now" button is now always displayed for simple, purchasable products, even when out of stock.
- **Style**
	- Added a new visual style for disabled "Buy Now" buttons, indicating when a product is out of stock.
- **Bug Fixes**
	- Disabled "Buy Now" buttons now prevent checkout actions and clicks when the product is out of stock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->