### PR TITLE
fix: add validation handling to floating notification bar components

### DIFF
--- a/Includes/Modules/FloatingNotificationBar/assets/src/components/DefaultBanner.js
+++ b/Includes/Modules/FloatingNotificationBar/assets/src/components/DefaultBanner.js
@@ -10,7 +10,7 @@ import BarIcon from "./BarIcon";
 import ButtonAction from "./ButtonAction";
 
 function DefaultBanner(props) {
-  const { formData, setFormData, onFieldChange } = props;
+  const { formData, setFormData, onFieldChange, onValidationChange } = props;
 
   const checkboxesOption = [
     {
@@ -120,7 +120,8 @@ function DefaultBanner(props) {
           "sgsb_floating_notification_bar_coupon_coundown",
           "",
           formData,
-          onFieldChange
+          onFieldChange,
+          onValidationChange
         )}
       </SettingsSection>
       {applyFilters(

--- a/Includes/Modules/FloatingNotificationBar/assets/src/components/FloatingNotificationBarLayout.js
+++ b/Includes/Modules/FloatingNotificationBar/assets/src/components/FloatingNotificationBarLayout.js
@@ -1,20 +1,17 @@
-import { notification } from 'antd';
-import { __ } from '@wordpress/i18n';
-import {
-  useEffect,
-  useState,
-} from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
-import { Fragment } from 'react';
-import SettingsTab from './SettingsTab';
-import DesignTab from './DesignTab';
-import Preview from './Preview';
-
-import PanelHeader from '../../../../../../assets/src/components/settings/Panels/PanelHeader';
-import PanelContainer from '../../../../../../assets/src/components/settings/Panels/PanelContainer';
-import PanelRow from '../../../../../../assets/src/components/settings/Panels/PanelRow';
-import PanelPreview from '../../../../../../assets/src/components/settings/Panels/PanelPreview';
-import PanelSettings from '../../../../../../assets/src/components/settings/Panels/PanelSettings';
+import { notification } from "antd";
+import { __ } from "@wordpress/i18n";
+import { useEffect, useState, useMemo } from "@wordpress/element";
+import { useDispatch } from "@wordpress/data";
+import { Fragment } from "react";
+import SettingsTab from "./SettingsTab";
+import DesignTab from "./DesignTab";
+import Preview from "./Preview";
+import { applyFilters } from "@wordpress/hooks";
+import PanelHeader from "../../../../../../assets/src/components/settings/Panels/PanelHeader";
+import PanelContainer from "../../../../../../assets/src/components/settings/Panels/PanelContainer";
+import PanelRow from "../../../../../../assets/src/components/settings/Panels/PanelRow";
+import PanelPreview from "../../../../../../assets/src/components/settings/Panels/PanelPreview";
+import PanelSettings from "../../../../../../assets/src/components/settings/Panels/PanelSettings";
 import TouchPreview from "sales-booster/src/components/settings/Panels/TouchPreview";
 
 function FloatingNotificationBarLayout({
@@ -25,6 +22,7 @@ function FloatingNotificationBarLayout({
 }) {
   const { setPageLoading } = useDispatch('sgsb');
   const [buttonLoading, setButtonLoading] = useState(false);
+  const [hasValidationError, setHasValidationError] = useState(false);
 
   let [searchParams, setSearchParams] = useSearchParams('general');
   const tabName = searchParams.get('tab_name') || 'general';
@@ -144,10 +142,12 @@ function FloatingNotificationBarLayout({
       });
     }
   };
-
   const onFormSave = (type) => {
-    setButtonLoading(true);
+    if (hasValidationError) {
+      return;
+    }
 
+    setButtonLoading(true);
     const data = {
       action: 'sgsb_floating_notification_bar_save_settings',
       _ajax_nonce: sgsbAdmin.nonce,
@@ -166,7 +166,6 @@ function FloatingNotificationBarLayout({
       });
   };
 
-
   const tabPanels = [
     {
       key: 'general',
@@ -180,6 +179,8 @@ function FloatingNotificationBarLayout({
           buttonLoading={buttonLoading}
           upgradeTeaser={!isProEnabled}
           onFormReset={onFormReset}
+          isDisabled={hasValidationError}
+          onValidationChange={setHasValidationError}
         />
       ),
     },

--- a/Includes/Modules/FloatingNotificationBar/assets/src/components/SettingsTab.js
+++ b/Includes/Modules/FloatingNotificationBar/assets/src/components/SettingsTab.js
@@ -10,6 +10,8 @@ function SettingsTab(props) {
     buttonLoading,
     upgradeTeaser,
     onFormReset,
+    isDisabled,
+    onValidationChange,
   } = props;
 
   return (
@@ -19,11 +21,13 @@ function SettingsTab(props) {
         setFormData={setFormData}
         onFieldChange={onFieldChange}
         upgradeTeaser={upgradeTeaser}
+        onValidationChange={onValidationChange}
       />
       <ActionsHandler
         resetHandler={onFormReset}
         loadingHandler={buttonLoading}
         saveHandler={onFormSave}
+        isDisabled={isDisabled}
       />
 
       <p className="ant-form-item-explain" style={{ margin: "15px 0 0 0" }}>


### PR DESCRIPTION

Related pr: https://github.com/getdokan/storegrowth-sales-booster-pro/pull/87
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added real-time validation for the Floating Notification Bar settings, preventing saving when there are validation errors.
  - Save button is now automatically disabled if validation errors are detected in the form.

- **Enhancements**
  - Improved feedback and state management for form validation within the Floating Notification Bar settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->