### PR TITLE
🎨 enhance: Update quick view button default styling

### DIFF
--- a/Includes/Modules/QuickView/Includes/EnqueueScript.php
+++ b/Includes/Modules/QuickView/Includes/EnqueueScript.php
@@ -230,7 +230,7 @@ class EnqueueScript {
 		$settings = get_option( 'sgsb_quick_view_settings' );
 
 		$modal_bg_color       = sgsb_find_option_setting( $settings, 'modal_background_color', '#ffffff' );
-		$button_color         = sgsb_find_option_setting( $settings, 'button_color', '#000000' );
+		$button_color         = sgsb_find_option_setting( $settings, 'button_color', '#0875FF' );
 		$button_text_color    = sgsb_find_option_setting( $settings, 'button_text_color', '#ffffff' );
 		$button_border_radius = sgsb_find_option_setting( $settings, 'button_border_radius', 4 );
 		$show_image           = sgsb_find_option_setting( $settings, 'show_image', 4 );

--- a/Includes/Modules/QuickView/assets/src/components/QuickViewLayout.jsx
+++ b/Includes/Modules/QuickView/assets/src/components/QuickViewLayout.jsx
@@ -45,7 +45,7 @@ function QuickViewLayout({ navigate, useSearchParams, moduleId }) {
     show_quick_icon: true,
     enable_close_button: true,
     show_view_details_button: false,
-    button_color: "#000000",
+    button_color: "#0875FF",
     button_text_color: "#ffffff",
     modal_background_color: "#ffffff",
     navigation_background: "#000000",


### PR DESCRIPTION
* Fixes: https://github.com/getdokan/storegrowth-sales-booster-pro/issues/82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the default button color in the Quick View feature from black to blue for a refreshed appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->