### PR TITLE
fix: Overlapping free shipping and floating bars on storefront

### DIFF
--- a/Includes/Modules/FloatingNotificationBar/Includes/EnqueueScript.php
+++ b/Includes/Modules/FloatingNotificationBar/Includes/EnqueueScript.php
@@ -7,6 +7,7 @@
 
 namespace STOREGROWTH\SPSB\Modules\FloatingNotificationBar\Includes;
 
+use STOREGROWTH\SPSB\Modules\ProgressiveDiscountBanner\Includes\Helper as PD_Helper;
 use STOREGROWTH\SPSB\Traits\Singleton;
 
 // If this file is called directly, abort.
@@ -55,7 +56,16 @@ class EnqueueScript {
 			filemtime( sgsb_modules_path( 'FloatingNotificationBar/assets/js/sgsb-pd-banner-bar-remove.js' ) ),
 			true
 		);
-		$localized_fnb_data = Helper::sgsb_floating_notification_bar_get_settings();
+
+		$localized_fnb_data     = Helper::sgsb_floating_notification_bar_get_settings();
+        $enable_shipping_banner = sgsb_is_module_active( 'progressive-discount-banner' );
+
+        $localized_fnb_data['enable_shipping_banner'] = $enable_shipping_banner;
+        if ( $enable_shipping_banner ) {
+            $shipping_banner_settings                       = PD_Helper::sgsb_pd_banner_get_settings();
+            $localized_fnb_data['shipping_banner_height']   = $shipping_banner_settings['banner_height'] ?? 60;
+            $localized_fnb_data['shipping_banner_position'] = $shipping_banner_settings['bar_position'] ?? 'top';
+        }
 
 		// Use wp_localize_script to pass the data to your script.
 		wp_localize_script( 'sgsb-floating-notification-bar-remove', 'sgsb_fnb_data', $localized_fnb_data );

--- a/Includes/Modules/FloatingNotificationBar/Includes/EnqueueScript.php
+++ b/Includes/Modules/FloatingNotificationBar/Includes/EnqueueScript.php
@@ -57,7 +57,7 @@ class EnqueueScript {
 			true
 		);
 
-        $localized_fnb_data     = Helper::sgsb_floating_notification_bar_get_settings();
+                $localized_fnb_data     = Helper::sgsb_floating_notification_bar_get_settings();
                 $enable_shipping_banner = sgsb_is_module_active( 'progressive-discount-banner' );
 
                 $localized_fnb_data['enable_shipping_banner'] = $enable_shipping_banner;

--- a/Includes/Modules/FloatingNotificationBar/Includes/EnqueueScript.php
+++ b/Includes/Modules/FloatingNotificationBar/Includes/EnqueueScript.php
@@ -57,15 +57,15 @@ class EnqueueScript {
 			true
 		);
 
-		$localized_fnb_data     = Helper::sgsb_floating_notification_bar_get_settings();
-        $enable_shipping_banner = sgsb_is_module_active( 'progressive-discount-banner' );
+        $localized_fnb_data     = Helper::sgsb_floating_notification_bar_get_settings();
+                $enable_shipping_banner = sgsb_is_module_active( 'progressive-discount-banner' );
 
-        $localized_fnb_data['enable_shipping_banner'] = $enable_shipping_banner;
-        if ( $enable_shipping_banner ) {
-            $shipping_banner_settings                       = PD_Helper::sgsb_pd_banner_get_settings();
-            $localized_fnb_data['shipping_banner_height']   = $shipping_banner_settings['banner_height'] ?? 60;
-            $localized_fnb_data['shipping_banner_position'] = $shipping_banner_settings['bar_position'] ?? 'top';
-        }
+                $localized_fnb_data['enable_shipping_banner'] = $enable_shipping_banner;
+                if ( $enable_shipping_banner ) {
+                    $shipping_banner_settings                       = PD_Helper::sgsb_pd_banner_get_settings();
+                    $localized_fnb_data['shipping_banner_height']   = $shipping_banner_settings['banner_height'] ?? 60;
+                    $localized_fnb_data['shipping_banner_position'] = $shipping_banner_settings['bar_position'] ?? 'top';
+                }
 
 		// Use wp_localize_script to pass the data to your script.
 		wp_localize_script( 'sgsb-floating-notification-bar-remove', 'sgsb_fnb_data', $localized_fnb_data );

--- a/Includes/Modules/FloatingNotificationBar/assets/js/sgsb-pd-banner-bar-remove.js
+++ b/Includes/Modules/FloatingNotificationBar/assets/js/sgsb-pd-banner-bar-remove.js
@@ -132,12 +132,18 @@
         ".sgsb-floating-notification-bar-remove",
         function () {
           const slideDirection = bar_position !== 'top' ? 'translateY(500%)' : 'translateY(-500%)';
-          $( '.sgsb-floating-notification-bar-wrapper' ).css( 'transform', slideDirection );
+          $('.sgsb-floating-notification-bar-wrapper').css('transform', slideDirection);
           paddingRemoverBody();
           setTimeout(removeClassToBodyToHandleBannerVisibility, 500);
           localStorage.setItem("fn_banner_hidden_time", now + 10 * 60 * 1000);
         }
       );
+
+      // Handle WooCommerce AJAX add to cart
+      $( document.body ).on( 'added_to_cart', function() {
+        const offset = document.body.classList.contains( 'admin-bar' ) ? 32 : 0;
+        $( '.sgsb-floating-notification-bar-wrapper' ).css( { top: `${offset}px` } );
+      });
     });
 
     // Cupon Code Functionality

--- a/Includes/Modules/FloatingNotificationBar/assets/js/sgsb-pd-banner-bar-remove.js
+++ b/Includes/Modules/FloatingNotificationBar/assets/js/sgsb-pd-banner-bar-remove.js
@@ -56,9 +56,10 @@
         isPDBannerVisible = ! pdBannerHiddenTime || parseInt( pdBannerHiddenTime ) < now;
 
       if ( enableShippingBanner && isPDBannerVisible && 'top' === shippingBannerPosition ) {
-        let shippingBannerHeight = sgsb_fnb_data?.shipping_banner_height;
+        let shippingBannerHeight = sgsb_fnb_data?.shipping_banner_height,
+          offset = document.body.classList.contains( 'admin-bar' ) ? 32 : 0;
         $( '.sgsb-floating-notification-bar-wrapper' ).css({
-          top: `${ parseInt( shippingBannerHeight ) + 32 }px`,
+          top: `${ parseInt( shippingBannerHeight ) + offset }px`,
         });
       }
     }

--- a/Includes/Modules/FloatingNotificationBar/assets/js/sgsb-pd-banner-bar-remove.js
+++ b/Includes/Modules/FloatingNotificationBar/assets/js/sgsb-pd-banner-bar-remove.js
@@ -50,11 +50,11 @@
     };
 
     const updateBannerPosition = () => {
-      let enableShippingBanner = sgsb_fnb_data.enable_shipping_banner,
-        shippingBannerPosition = sgsb_fnb_data.shipping_banner_position;
+      let enableShippingBanner = sgsb_fnb_data?.enable_shipping_banner,
+        shippingBannerPosition = sgsb_fnb_data?.shipping_banner_position;
 
       if ( enableShippingBanner && 'top' === shippingBannerPosition ) {
-        let shippingBannerHeight = sgsb_fnb_data.shipping_banner_height;
+        let shippingBannerHeight = sgsb_fnb_data?.shipping_banner_height;
         $( '.sgsb-floating-notification-bar-wrapper' ).css({
           top: `${ parseInt( shippingBannerHeight ) + 32 }px`,
         });

--- a/Includes/Modules/FloatingNotificationBar/assets/js/sgsb-pd-banner-bar-remove.js
+++ b/Includes/Modules/FloatingNotificationBar/assets/js/sgsb-pd-banner-bar-remove.js
@@ -46,7 +46,20 @@
     const bannerShow = () => {
       $(".sgsb-floating-notification-bar-wrapper").fadeIn(1000);
       paddingAdderBody();
+      updateBannerPosition();
     };
+
+    const updateBannerPosition = () => {
+      let enableShippingBanner = sgsb_fnb_data.enable_shipping_banner,
+        shippingBannerPosition = sgsb_fnb_data.shipping_banner_position;
+
+      if ( enableShippingBanner && 'top' === shippingBannerPosition ) {
+        let shippingBannerHeight = sgsb_fnb_data.shipping_banner_height;
+        $( '.sgsb-floating-notification-bar-wrapper' ).css({
+          top: `${ parseInt( shippingBannerHeight ) + 32 }px`,
+        });
+      }
+    }
 
     const bannerHide = () => {
       $(".sgsb-floating-notification-bar-wrapper").hide();

--- a/Includes/Modules/FloatingNotificationBar/assets/js/sgsb-pd-banner-bar-remove.js
+++ b/Includes/Modules/FloatingNotificationBar/assets/js/sgsb-pd-banner-bar-remove.js
@@ -51,9 +51,11 @@
 
     const updateBannerPosition = () => {
       let enableShippingBanner = sgsb_fnb_data?.enable_shipping_banner,
-        shippingBannerPosition = sgsb_fnb_data?.shipping_banner_position;
+        shippingBannerPosition = sgsb_fnb_data?.shipping_banner_position,
+        pdBannerHiddenTime = localStorage.getItem( 'banner_hidden_time' ),
+        isPDBannerVisible = ! pdBannerHiddenTime || parseInt( pdBannerHiddenTime ) < now;
 
-      if ( enableShippingBanner && 'top' === shippingBannerPosition ) {
+      if ( enableShippingBanner && isPDBannerVisible && 'top' === shippingBannerPosition ) {
         let shippingBannerHeight = sgsb_fnb_data?.shipping_banner_height;
         $( '.sgsb-floating-notification-bar-wrapper' ).css({
           top: `${ parseInt( shippingBannerHeight ) + 32 }px`,
@@ -128,10 +130,8 @@
         "click",
         ".sgsb-floating-notification-bar-remove",
         function () {
-          $(".sgsb-floating-notification-bar-wrapper").css(
-            "transform",
-            "translateY(-200%)"
-          );
+          const slideDirection = bar_position !== 'top' ? 'translateY(500%)' : 'translateY(-500%)';
+          $( '.sgsb-floating-notification-bar-wrapper' ).css( 'transform', slideDirection );
           paddingRemoverBody();
           setTimeout(removeClassToBodyToHandleBannerVisibility, 500);
           localStorage.setItem("fn_banner_hidden_time", now + 10 * 60 * 1000);

--- a/Includes/Modules/ProgressiveDiscountBanner/assets/js/sgsb-pd-banner-bar-remove.js
+++ b/Includes/Modules/ProgressiveDiscountBanner/assets/js/sgsb-pd-banner-bar-remove.js
@@ -107,10 +107,12 @@
       }
 
       $(document).on("click", ".sgsb-pd-banner-bar-remove", function () {
-        $(".sgsb-pd-banner-bar-wrapper").css("transform", "translateY(-200%)");
+        const slideDirection = bar_position !== 'top' ? 'translateY(500%)' : 'translateY(-500%)';
+        $( '.sgsb-pd-banner-bar-wrapper' ).css( 'transform', slideDirection );
         paddingRemoverBody();
         setTimeout(removeClassToBodyToHandleBannerVisibility, 500);
         localStorage.setItem("banner_hidden_time", now + 10 * 60 * 1000);
+        $( '.sgsb-floating-notification-bar-wrapper' ).css({ top: '32px' });
       });
     });
   } else {

--- a/Includes/Modules/ProgressiveDiscountBanner/assets/js/sgsb-pd-banner-bar-remove.js
+++ b/Includes/Modules/ProgressiveDiscountBanner/assets/js/sgsb-pd-banner-bar-remove.js
@@ -107,12 +107,13 @@
       }
 
       $(document).on("click", ".sgsb-pd-banner-bar-remove", function () {
-        const slideDirection = bar_position !== 'top' ? 'translateY(500%)' : 'translateY(-500%)';
+        const slideDirection = bar_position !== 'top' ? 'translateY(500%)' : 'translateY(-500%)',
+          offset = document.body.classList.contains( 'admin-bar' ) ? 32 : 0;
         $( '.sgsb-pd-banner-bar-wrapper' ).css( 'transform', slideDirection );
         paddingRemoverBody();
         setTimeout(removeClassToBodyToHandleBannerVisibility, 500);
         localStorage.setItem("banner_hidden_time", now + 10 * 60 * 1000);
-        $( '.sgsb-floating-notification-bar-wrapper' ).css({ top: '32px' });
+        $( '.sgsb-floating-notification-bar-wrapper' ).css({ top: `${ offset }px` });
       });
     });
   } else {

--- a/Includes/functions.php
+++ b/Includes/functions.php
@@ -156,7 +156,7 @@ if ( ! function_exists( 'sgsb_is_module_active' ) ) {
     /**
      * Check if the module is active.
      *
-     * @since 1.0.3
+     * @since 1.28.14
      *
      * @param string $module_id The module ID to check.
      *

--- a/Includes/functions.php
+++ b/Includes/functions.php
@@ -162,10 +162,10 @@ if ( ! function_exists( 'sgsb_is_module_active' ) ) {
      *
      * @return boolean True if the module is active, false otherwise.
      */
-	function sgsb_is_module_active( $module_id ) {
-		$modules 		= \STOREGROWTH\SPSB\Modules::instance();
-		$active_modules = $modules->get_active_module_ids();
+function sgsb_is_module_active( $module_id ) {
+    $modules 		= \STOREGROWTH\SPSB\Modules::instance();
+    $active_modules = $modules->get_active_module_ids();
 
-		return in_array( $module_id, $active_modules, true );
-	}
+    return in_array( $module_id, $active_modules, true );
+}
 }

--- a/Includes/functions.php
+++ b/Includes/functions.php
@@ -163,7 +163,7 @@ if ( ! function_exists( 'sgsb_is_module_active' ) ) {
      * @return boolean True if the module is active, false otherwise.
      */
     function sgsb_is_module_active( $module_id ) {
-        $modules 		= \STOREGROWTH\SPSB\Modules::instance();
+        $modules        = \STOREGROWTH\SPSB\Modules::instance();
         $active_modules = $modules->get_active_module_ids();
 
         return in_array( $module_id, $active_modules, true );

--- a/Includes/functions.php
+++ b/Includes/functions.php
@@ -162,10 +162,10 @@ if ( ! function_exists( 'sgsb_is_module_active' ) ) {
      *
      * @return boolean True if the module is active, false otherwise.
      */
-function sgsb_is_module_active( $module_id ) {
-    $modules 		= \STOREGROWTH\SPSB\Modules::instance();
-    $active_modules = $modules->get_active_module_ids();
+    function sgsb_is_module_active( $module_id ) {
+        $modules 		= \STOREGROWTH\SPSB\Modules::instance();
+        $active_modules = $modules->get_active_module_ids();
 
-    return in_array( $module_id, $active_modules, true );
-}
+        return in_array( $module_id, $active_modules, true );
+    }
 }

--- a/Includes/functions.php
+++ b/Includes/functions.php
@@ -151,3 +151,21 @@ if ( ! function_exists( 'sgsb_get_day_for_schedule' ) ) {
 		);
 	}
 }
+
+if ( ! function_exists( 'sgsb_is_module_active' ) ) {
+    /**
+     * Check if the module is active.
+     *
+     * @since 1.0.3
+     *
+     * @param string $module_id The module ID to check.
+     *
+     * @return boolean True if the module is active, false otherwise.
+     */
+	function sgsb_is_module_active( $module_id ) {
+		$modules 		= \STOREGROWTH\SPSB\Modules::instance();
+		$active_modules = $modules->get_active_module_ids();
+
+		return in_array( $module_id, $active_modules, true );
+	}
+}


### PR DESCRIPTION
### Fix Free shipping and Floating bars banner overlapping on frontend preview

Closes: [[Floating Bar] [Free Shipping] Overlapping Bars in storefront ](https://github.com/getdokan/storegrowth-sales-booster-pro/issues/74)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced integration between the floating notification bar and the shipping banner, allowing dynamic adjustment of the notification bar position when both are active.
	- Added a check to detect active modules for better feature coordination.
- **Bug Fixes**
	- Improved banner dismissal animation to slide in the correct direction based on banner position.
- **Style**
	- Updated visual transitions for banner removal to provide a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->