### PR TITLE
feat: integrate WordPress hooks for countdown timer data and tab panels

### DIFF
--- a/Includes/Modules/CountdownTimer/assets/src/components/SalesCountdownLayout.js
+++ b/Includes/Modules/CountdownTimer/assets/src/components/SalesCountdownLayout.js
@@ -18,6 +18,7 @@ import Layout2 from "../../images/layout/layout-2.svg";
 import Custom from "../../images/layout/custom.svg";
 import "../styles/countdown-timer.css";
 import TouchPreview from "sales-booster/src/components/settings/Panels/TouchPreview";
+import { applyFilters } from '@wordpress/hooks';
 
 function SalesCountdownLayout({ navigate, useSearchParams, moduleId }) {
   const isProEnabled = sgsbAdmin.isPro;
@@ -59,11 +60,14 @@ function SalesCountdownLayout({ navigate, useSearchParams, moduleId }) {
     product_page_countdown_enable : true,
   };
 
+  // apply filters to allow other modules to modify the initial data.
+    const filteredInitialData = applyFilters( 'sgsb_countdown_timer_initial_data', initialSalesCountdownData );
+
   const [formData, setFormData] = useState({
-    ...initialSalesCountdownData,
+    ...filteredInitialData,
   });
   const [undoData, setUndoData] = useState({
-    ...initialSalesCountdownData,
+    ...filteredInitialData,
   });
 
   const undoState = {
@@ -79,7 +83,7 @@ function SalesCountdownLayout({ navigate, useSearchParams, moduleId }) {
   };
 
   const onFormReset = () => {
-    setFormData({ ...initialSalesCountdownData });
+    setFormData({ ...filteredInitialData });
     setShowUndo( { ...undoState } );
   };
 
@@ -134,6 +138,11 @@ function SalesCountdownLayout({ navigate, useSearchParams, moduleId }) {
         message: "Design Section",
         description: "Design section data updated successfully.",
       });
+    } else {
+        notification["success"]({
+            message: __("Settings Updated", "storegrowth-sales-booster"),
+            description: __("Settings updated successfully.", "storegrowth-sales-booster"),
+        });
     }
   };
 
@@ -239,6 +248,17 @@ function SalesCountdownLayout({ navigate, useSearchParams, moduleId }) {
       ),
     },
   ];
+
+  // wp filter to allow other modules to add their own tabs.
+    const filteredTabPanel=applyFilters(
+        "sgsb_countdown_timer_tab_panels",
+        tabPanels,
+        formData,
+        onFieldChange,
+        onFormSave,
+        buttonLoading,
+        onFormReset
+    );
   return (
     <Fragment>
       <PanelHeader
@@ -248,7 +268,7 @@ function SalesCountdownLayout({ navigate, useSearchParams, moduleId }) {
       <PanelContainer>
         <PanelRow>
           <PanelSettings
-            tabPanels={tabPanels}
+            tabPanels={filteredTabPanel}
             changeHandler={changeTab}
             activeTab={tabName ? tabName : "general"}
             colSpan={showPreview && tabName ? 12 : 24}

--- a/Includes/Modules/CountdownTimer/assets/src/components/SalesCountdownLayout.js
+++ b/Includes/Modules/CountdownTimer/assets/src/components/SalesCountdownLayout.js
@@ -126,24 +126,17 @@ function SalesCountdownLayout({ navigate, useSearchParams, moduleId }) {
   };
 
   const notificationMessage = (type) => {
-    if (type == "general_settings") {
-      notification["success"]({
-        message: "Settings Section",
-        description: "General settings section data updated successfully.",
-      });
-    }
-
-    if (type == "design") {
-      notification["success"]({
-        message: "Design Section",
-        description: "Design section data updated successfully.",
-      });
-    } else {
+      const typeMapping = {
+        general_settings: "General Settings Section",
+        design: "Design Section",
+        vendor_settings: "Vendor Section",
+      }
         notification["success"]({
-            message: __("Settings Updated", "storegrowth-sales-booster"),
-            description: __("Settings updated successfully.", "storegrowth-sales-booster"),
+            message: typeMapping[type] || __("Settings Updated", "storegrowth-sales-booster"),
+            description: typeMapping[type]
+              ? `${typeMapping[type]} data updated successfully.`
+              : __("Settings updated successfully.", "storegrowth-sales-booster"),
         });
-    }
   };
 
   const onFormSave = (type) => {


### PR DESCRIPTION
related PR : https://github.com/getdokan/storegrowth-sales-booster-pro/pull/91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for external customization of countdown timer settings and UI tabs through WordPress filters, allowing enhanced extensibility.
  - Introduced a generic success notification message for broader settings update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->