### PR TITLE
🧩 feat: BOGO compatibility with Dokan

### DIFF
--- a/Includes/Modules/BoGo/BoGoModule.php
+++ b/Includes/Modules/BoGo/BoGoModule.php
@@ -104,6 +104,7 @@ class BoGoModule implements ModuleSkeleton {
 		Includes\OrderBogo::instance();
 		Includes\Ajax::instance();
 		Includes\EnqueueScript::instance();
+		Includes\Api::instance();
 
 			/**
 		 * Module initialized.

--- a/Includes/Modules/BoGo/Includes/Ajax.php
+++ b/Includes/Modules/BoGo/Includes/Ajax.php
@@ -222,7 +222,7 @@ class Ajax {
 			wp_send_json_success( $result );
 		} else {
 			$bogos = $this->bogo->get_items();
-			wp_send_json_success( $bogos );
+			wp_send_json_success( $bogos['data'] ?? [] );
 		}
 	}
 

--- a/Includes/Modules/BoGo/Includes/Ajax.php
+++ b/Includes/Modules/BoGo/Includes/Ajax.php
@@ -22,9 +22,18 @@ class Ajax {
 	use Singleton;
 
 	/**
+	 * BoGo Instance.
+	 *
+	 * @var BoGo
+	 */
+	private $bogo;
+
+	/**
 	 * Constructor of Bootstrap class.
 	 */
 	private function __construct() {
+		$this->bogo = $this->get_bogo_instance();
+
 		add_action( 'wp_ajax_bogo_create', array( $this, 'bogo_create' ) );
 		add_action( 'wp_ajax_nopriv_bogo_create', array( $this, 'bogo_create' ) );
 
@@ -51,6 +60,17 @@ class Ajax {
 
 		add_action( 'wp_ajax_update_offer_product', array( $this, 'handle_update_offer_product' ) );
 		add_action( 'wp_ajax_nopriv_update_offer_product', array( $this, 'handle_update_offer_product' ) );
+	}
+
+	/**
+	 * Get BoGo Instance.
+	 *
+	 * @since 1.29.0
+	 *
+	 * @return BoGo
+	 */
+	private function get_bogo_instance() {
+		return new BoGo();
 	}
 
 	public function handle_update_offer_product() {
@@ -143,31 +163,18 @@ class Ajax {
 	public function bogo_create() {
 		check_ajax_referer( 'ajd_protected' );
 
-		$bogo_detail = $this->get_sanitized_create_bogo_data();
-
-		$my_post = array(
-			'post_title'   => $bogo_detail['name_of_order_bogo'],
-			'post_status'  => 'publish',
-			'post_type'    => 'sgsb_bogo',
-			'post_excerpt' => maybe_serialize( $bogo_detail ),
-			'post_content' => 'Not defined',
-
-		);
-		if ( 0 === $bogo_detail['offer_product_id'] ) {
-			$args_bogo = array(
-				'post_type'      => 'sgsb_bogo',
-				'posts_per_page' => - 1,
-			);
-			$bogo_list = get_posts( $args_bogo );
-			if ( is_array( $bogo_list ) && count( $bogo_list ) >= 2 && ! SGSB_PRO_ACTIVE ) {
-				// don't allow creating more than 2 bogos.
-				return;
-			}
-			echo esc_attr( wp_insert_post( $my_post ) );
-		} elseif ( ! empty( $bogo_detail['offer_product_id'] ) ) {
-			$my_post['ID'] = $bogo_detail['offer_product_id'];
-			wp_update_post( $my_post );
+		if ( ! isset( $_POST['data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			wp_send_json_error( __( 'No data provided.', 'storegrowth-sales-booster-pro' ) );
 		}
+
+		$data = $_POST['data']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing
+
+		$result = $this->bogo->create( $data );
+
+		if ( is_wp_error($result) ) {
+			wp_send_json_error( $result->get_error_message() );
+		}
+		wp_send_json_success( $result );
 
 		die();
 	}
@@ -204,24 +211,17 @@ class Ajax {
 	 */
 	public function bogo_list() {
 		check_ajax_referer( 'ajd_protected' );
+
 		$bogo_id = isset( $_POST['data'] ) ? intval( wp_unslash( $_POST['data'] ) ) : null;
 
 		if ( $bogo_id ) {
-			$bogo = get_post( $bogo_id );
-			wp_send_json_success( maybe_unserialize( $bogo->post_excerpt ) );
+			$result = $this->bogo->get_item($bogo_id);
+            if ( is_wp_error($result) ) {
+                wp_send_json_error( $result->get_error_message() );
+            }
+			wp_send_json_success( $result );
 		} else {
-			$args_bogo = array(
-				'post_type'      => 'sgsb_bogo',
-				'posts_per_page' => - 1,
-			);
-			$bogo_list = get_posts( $args_bogo );
-			$bogos     = array();
-			foreach ( $bogo_list as $bogo ) {
-				$post_excerpt       = maybe_unserialize( $bogo->post_excerpt );
-				$post_excerpt['id'] = $bogo->ID;
-
-				$bogos[] = $post_excerpt;
-			}
+			$bogos = $this->bogo->get_items();
 			wp_send_json_success( $bogos );
 		}
 	}
@@ -250,30 +250,35 @@ class Ajax {
 	 */
 	public function bogo_delete() {
 		check_ajax_referer( 'ajd_protected' );
+
 		$bogo_id = isset( $_POST['data'] ) ? intval( wp_unslash( $_POST['data'] ) ) : null;
-		wp_delete_post( $bogo_id, true );
+        $result  = $this->bogo->delete($bogo_id);
+
+        if ( is_wp_error($result) ) {
+            wp_send_json_error( $result->get_error_message() );
+        }
 		wp_send_json_success( 'yes' );
 	}
 
 	/**
-	 * Bogo product delete.
+	 * Bogo product status handler.
 	 */
 	public function bogo_status_handler() {
 		check_ajax_referer( 'ajd_protected' );
+
 		$data    = ! empty( $_POST['data'] ) ? wc_clean( wp_unslash( $_POST['data'] ) ) : array();
 		$post_id = ! empty( $data['id'] ) ? intval( $data['id'] ) : 0;
 
 		if ( empty( $post_id ) || ! isset( $data['status'] ) ) {
-			return wp_send_json_error( __( 'Offer id & status is required', 'storegrowth-sales-booster' ) );
+			wp_send_json_error( __( 'Offer id & status is required', 'storegrowth-sales-booster' ) );
 		}
 
-		$bogo_post     = get_post( $post_id );
-		$bogo_settings = ! empty( $bogo_post->post_excerpt ) ? maybe_unserialize( $bogo_post->post_excerpt ) : array();
+        $result = $this->bogo->set_status( $post_id, $data['status'] );
 
-		$bogo_settings['bogo_status'] = filter_var( $data['status'], FILTER_VALIDATE_BOOLEAN ) ? 'yes' : 'no';
-		$bogo_post->post_excerpt      = maybe_serialize( $bogo_settings );
+        if ( is_wp_error( $result ) ) {
+            wp_send_json_error( $result->get_error_message() );
+        }
 
-		wp_update_post( $bogo_post );
 		wp_send_json_success( $data['status'] );
 	}
 
@@ -323,61 +328,5 @@ class Ajax {
 		}
 
 		die();
-	}
-
-	/**
-	 * Sanitize create order bogo data.
-	 *
-	 * @return array
-	 */
-	private function get_sanitized_create_bogo_data() {
-		if ( ! isset( $_POST['data'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			return array();
-		}
-
-		$data = $_POST['data']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing
-
-		if ( empty( $data['target_products'] ) ) {
-			$data['target_products'] = array();
-		}
-
-		if ( empty( $data['target_categories'] ) ) {
-			$data['target_categories'] = array();
-		}
-
-		$data['name_of_order_bogo']                 = sanitize_text_field( $data['name_of_order_bogo'] );
-		$data['target_products']                    = wc_clean( $data['target_products'] );
-		$data['target_categories']                  = wc_clean( $data['target_categories'] );
-		$data['bogo_schedule']                      = ! empty( $data['bogo_schedule'] ) ? wc_clean( $data['bogo_schedule'] ) : array();
-		$data['smart_offer']                        = sanitize_text_field( $data['smart_offer'] );
-		$data['get_different_product_field']        = intval( $data['get_different_product_field'] );
-		$data['offer_type']                         = sanitize_text_field( $data['offer_type'] );
-		$data['discount_amount']                    = sanitize_text_field( $data['discount_amount'] );
-		$data['box_border_style']                   = sanitize_text_field( $data['box_border_style'] );
-		$data['box_border_color']                   = sanitize_text_field( $data['box_border_color'] );
-		$data['box_top_margin']                     = sanitize_text_field( $data['box_top_margin'] );
-		$data['box_bottom_margin']                  = sanitize_text_field( $data['box_bottom_margin'] );
-		$data['discount_background_color']          = sanitize_text_field( $data['discount_background_color'] );
-		$data['discount_text_color']                = sanitize_text_field( $data['discount_text_color'] );
-		$data['discount_font_size']                 = sanitize_text_field( $data['discount_font_size'] );
-		$data['product_description_text_color']     = sanitize_text_field( $data['product_description_text_color'] );
-		$data['product_description_font_size']      = sanitize_text_field( $data['product_description_font_size'] );
-		$data['accept_offer_background_color']      = sanitize_text_field( $data['accept_offer_background_color'] );
-		$data['accept_offer_text_color']            = sanitize_text_field( $data['accept_offer_text_color'] );
-		$data['accept_offer_font_size']             = sanitize_text_field( $data['accept_offer_font_size'] );
-		$data['offer_description_background_color'] = sanitize_text_field( $data['offer_description_background_color'] );
-		$data['offer_description_text_color']       = sanitize_text_field( $data['offer_description_text_color'] );
-		$data['offer_description_font_size']        = sanitize_text_field( $data['offer_description_font_size'] );
-		$data['offer_image_url']                    = esc_url_raw( $data['offer_image_url'] );
-		$data['offer_product_title']                = sanitize_text_field( $data['offer_product_title'] );
-		$data['offer_product_id']                   = intval( $data['offer_product_id'] );
-		$data['offer_discount_title']               = sanitize_text_field( $data['offer_discount_title'] );
-		$data['offer_fixed_price_title']            = sanitize_text_field( $data['offer_fixed_price_title'] );
-		$data['product_description']                = sanitize_text_field( $data['product_description'] );
-		$data['selection_title']                    = sanitize_text_field( $data['selection_title'] );
-		$data['offer_description']                  = sanitize_text_field( $data['offer_description'] );
-		$data['offer_product_regular_price']        = sanitize_text_field( $data['offer_product_regular_price'] );
-
-		return $data;
 	}
 }

--- a/Includes/Modules/BoGo/Includes/Api.php
+++ b/Includes/Modules/BoGo/Includes/Api.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace STOREGROWTH\SPSB\Modules\BoGo\Includes;
+
+use STOREGROWTH\SPSB\Traits\Singleton;
+use STOREGROWTH\SPSB\Modules\BoGo\Includes\REST\BogoController;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Bogo Class.
+ *
+ * @package SBFW
+ */
+class Api {
+
+    use Singleton;
+
+    /**
+     * Constructor of Bootstrap class.
+     */
+    private function __construct() {
+        $this->init_hooks();
+    }
+
+    /**
+     * Initialize hooks.
+     */
+    private function init_hooks() {
+        add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
+    }
+
+    /**
+     * Register REST API routes.
+     */
+    public function register_rest_routes() {
+        $controller = new BogoController();
+        $controller->register_routes();
+    }
+}

--- a/Includes/Modules/BoGo/Includes/Bogo.php
+++ b/Includes/Modules/BoGo/Includes/Bogo.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace STOREGROWTH\SPSB\Modules\BoGo\Includes;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Bogo Class.
+ *
+ * @package SBFW
+ */
+class Bogo {
+
+    /**
+     * Post Type for Bogo Offers.
+     *
+     * @since 1.29.0
+     *
+     * @var string
+     */
+    private string $post_type = 'sgsb_bogo';
+
+    /**
+     * Create a New Bogo Offer.
+     *
+     * @since 1.29.0
+     *
+     * @return int|WP_Error|void Post ID on success, WP_Error on failure
+     */
+    public function create( array $data ) {
+        if ( ! $data ) {
+            return new WP_Error( 'missing_data', __( 'No data provided', 'storegrowth-sales-booster-pro' ) );
+        }
+
+        $bogo_detail = $this->sanitize_create_bogo_data( $data );
+
+        if ( 0 === $bogo_detail['offer_product_id'] ) {
+            $bogo_list = $this->get_items();
+            if ( is_array( $bogo_list ) && count( $bogo_list ) >= 2 && ! SGSB_PRO_ACTIVE ) {
+                // don't allow creating more than 2 bogos.
+                return;
+            }
+
+            $args = [
+                'post_title'   => $bogo_detail['name_of_order_bogo'],
+                'post_status'  => 'publish',
+                'post_type'    => $this->post_type,
+                'post_excerpt' => maybe_serialize( $bogo_detail ),
+                'post_content' => 'Not defined',
+            ];
+
+            return wp_insert_post( $args, true );
+        } elseif ( ! empty( $bogo_detail['offer_product_id'] ) ) {
+            return $this->update( $bogo_detail['offer_product_id'], $bogo_detail );
+        }
+    }
+
+    /**
+     * Get a Single Bogo Offer by ID.
+     *
+     * @since 1.29.0
+     *
+     * @param int $id
+     *
+     * @return array|WP_Error
+     */
+    public function get_item( int $id ) {
+        $bogo = get_post( $id );
+
+        if ( ! $bogo || $bogo->post_type !== $this->post_type ) {
+            return new WP_Error( 'not_found', 'Bogo not found' );
+        }
+
+        $data       = maybe_unserialize( $bogo->post_excerpt );
+        $data['id'] = $bogo->ID;
+
+        return $data;
+    }
+
+    /**
+     * Get Bogo Offers.
+     *
+     * @since 1.29.0
+     *
+     * @param array $args
+     *
+     * @return array
+     */
+    public function get_items( array $args = [] ) {
+        $default = [
+            'post_type'      => $this->post_type,
+            'posts_per_page' => -1,
+        ];
+
+        $args      = wp_parse_args( $args, $default );
+        $bogo_list = get_posts( $args );
+        $bogos     = [];
+
+        foreach ( $bogo_list as $bogo ) {
+            $post_excerpt       = maybe_unserialize($bogo->post_excerpt);
+            $post_excerpt['id'] = $bogo->ID;
+            $bogos[]            = $post_excerpt;
+        }
+
+        return $bogos;
+    }
+
+    /**
+     * Update an Existing Bogo Offer.
+     *
+     * @since 1.29.0
+     *
+     * @param int   $id
+     * @param array $data
+     *
+     * @return int|WP_Error
+     */
+    public function update( int $id, array $data ) {
+        $args = [
+            'ID'           => $id,
+            'post_title'   => $data['name_of_order_bogo'] ?? '',
+            'post_excerpt' => maybe_serialize( $data ),
+        ];
+
+        return wp_update_post( $args, true );
+    }
+
+    /**
+     * Delete a Bogo Offer.
+     *
+     * @since 1.29.0
+     *
+     * @param int $id
+     *
+     * @return bool|WP_Error
+     */
+    public function delete( int $id ) {
+        $result = wp_delete_post( $id, true );
+
+        if ( ! $result ) {
+            return new WP_Error( 'delete_failed', 'Failed to delete Bogo' );
+        }
+
+        return true;
+    }
+
+    /**
+     * Set The Status of a Bogo Offer.
+     *
+     * @since 1.29.0
+     *
+     * @param int    $id
+     * @param string $status 'yes' or 'no'
+     *
+     * @return bool|WP_Error
+     */
+    public function set_status( int $id, string $status ) {
+        $bogo = get_post( $id );
+        if ( ! $bogo || $bogo->post_type !== $this->post_type ) {
+            return new WP_Error( 'not_found', 'Bogo not found' );
+        }
+
+        $bogo_settings                = ! empty( $bogo->post_excerpt ) ? maybe_unserialize( $bogo->post_excerpt ) : [];
+        $bogo_settings['bogo_status'] = filter_var( $status, FILTER_VALIDATE_BOOLEAN ) ? 'yes' : 'no';
+        $bogo->post_excerpt           = maybe_serialize( $bogo_settings );
+        $result                       = wp_update_post( $bogo, true ) ;
+
+        if ( is_wp_error( $result ) ) {
+            return $result;
+        }
+
+        return true;
+    }
+
+    /**
+     * Sanitize Create Order Bogo Data.
+     *
+     * @since 1.29.0
+     *
+     * @param array $data Data to sanitize.
+     *
+     * @return array
+     */
+    private function sanitize_create_bogo_data( array $data ) {
+        $data['name_of_order_bogo']                 = $data['name_of_order_bogo'] ? sanitize_text_field( $data['name_of_order_bogo'] ) : '';
+        $data['target_products']                    = $data['target_products'] ? wc_clean( $data['target_products'] ) : [];
+        $data['target_categories']                  = $data['target_categories'] ? wc_clean( $data['target_categories'] ) : [];
+        $data['bogo_schedule']                      = ! empty( $data['bogo_schedule'] ) ? wc_clean( $data['bogo_schedule'] ) : [];
+        $data['smart_offer']                        = $data['smart_offer'] ? sanitize_text_field( $data['smart_offer'] ) : '';
+        $data['get_different_product_field']        = $data['get_different_product_field'] ? intval( $data['get_different_product_field'] ) : 0;
+        $data['offer_type']                         = $data['offer_type'] ? sanitize_text_field( $data['offer_type'] ) : '';
+        $data['discount_amount']                    = $data['discount_amount'] ? sanitize_text_field( $data['discount_amount'] ) : '';
+        $data['box_border_style']                   = $data['box_border_style'] ? sanitize_text_field( $data['box_border_style'] ) : '';
+        $data['box_border_color']                   = $data['box_border_color'] ? sanitize_text_field( $data['box_border_color'] ) : '';
+        $data['box_top_margin']                     = $data['box_top_margin'] ? sanitize_text_field( $data['box_top_margin'] ) : '';
+        $data['box_bottom_margin']                  = $data['box_bottom_margin'] ? sanitize_text_field( $data['box_bottom_margin'] ) : '';
+        $data['discount_background_color']          = $data['discount_background_color'] ? sanitize_text_field( $data['discount_background_color'] ) : '';
+        $data['discount_text_color']                = $data['discount_text_color'] ? sanitize_text_field( $data['discount_text_color'] ) : '';
+        $data['discount_font_size']                 = $data['discount_font_size'] ? sanitize_text_field( $data['discount_font_size'] ) : '';
+        $data['product_description_text_color']     = $data['product_description_text_color'] ? sanitize_text_field( $data['product_description_text_color'] ) : '';
+        $data['product_description_font_size']      = $data['product_description_font_size'] ? sanitize_text_field( $data['product_description_font_size'] ) : '';
+        $data['accept_offer_background_color']      = $data['accept_offer_background_color'] ? sanitize_text_field( $data['accept_offer_background_color'] ) : '';
+        $data['accept_offer_text_color']            = $data['accept_offer_text_color'] ? sanitize_text_field( $data['accept_offer_text_color'] ) : '';
+        $data['accept_offer_font_size']             = $data['accept_offer_font_size'] ? sanitize_text_field( $data['accept_offer_font_size'] ) : '';
+        $data['offer_description_background_color'] = $data['offer_description_background_color'] ? sanitize_text_field( $data['offer_description_background_color'] ) : '';
+        $data['offer_description_text_color']       = $data['offer_description_text_color'] ? sanitize_text_field( $data['offer_description_text_color'] ) : '';
+        $data['offer_description_font_size']        = $data['offer_description_font_size'] ? sanitize_text_field( $data['offer_description_font_size'] ) : '';
+        $data['offer_image_url']                    = $data['offer_image_url'] ? esc_url_raw( $data['offer_image_url'] ) : '';
+        $data['offer_product_title']                = $data['offer_product_title'] ? sanitize_text_field( $data['offer_product_title'] ) : '';
+        $data['offer_product_id']                   = $data['offer_product_id'] ? intval( $data['offer_product_id'] ) : 0;
+        $data['offer_discount_title']               = $data['offer_discount_title'] ? sanitize_text_field( $data['offer_discount_title'] ) : '';
+        $data['offer_fixed_price_title']            = $data['offer_fixed_price_title'] ? sanitize_text_field( $data['offer_fixed_price_title'] ) : '';
+        $data['product_description']                = $data['product_description'] ? sanitize_text_field( $data['product_description'] ) : '';
+        $data['selection_title']                    = $data['selection_title'] ? sanitize_text_field( $data['selection_title'] ) : '';
+        $data['offer_description']                  = $data['offer_description'] ? sanitize_text_field( $data['offer_description'] ) : '';
+        $data['offer_product_regular_price']        = $data['offer_product_regular_price'] ? sanitize_text_field( $data['offer_product_regular_price'] ) : '';
+
+        return $data;
+    }
+}

--- a/Includes/Modules/BoGo/Includes/Bogo.php
+++ b/Includes/Modules/BoGo/Includes/Bogo.php
@@ -3,6 +3,7 @@
 namespace STOREGROWTH\SPSB\Modules\BoGo\Includes;
 
 use WP_Error;
+use WP_Query;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -31,7 +32,7 @@ class Bogo {
      */
     public function create( array $data ) {
         if ( ! $data ) {
-            return new WP_Error( 'missing_data', __( 'No data provided', 'storegrowth-sales-booster-pro' ) );
+            return new WP_Error( 'missing_data', __( 'No data provided', 'storegrowth-sales-booster' ) );
         }
 
         $bogo_detail = $this->sanitize_create_bogo_data( $data );
@@ -48,7 +49,7 @@ class Bogo {
                 'post_status'  => 'publish',
                 'post_type'    => $this->post_type,
                 'post_excerpt' => maybe_serialize( $bogo_detail ),
-                'post_content' => 'Not defined',
+                'post_content' => __( 'Not defined', 'storegrowth-sales-booster' ),
             ];
 
             return wp_insert_post( $args, true );
@@ -70,7 +71,7 @@ class Bogo {
         $bogo = get_post( $id );
 
         if ( ! $bogo || $bogo->post_type !== $this->post_type ) {
-            return new WP_Error( 'not_found', 'Bogo not found' );
+            return new WP_Error( 'not_found', __( 'Bogo not found', 'storegrowth-sales-booster' ) );
         }
 
         $data       = maybe_unserialize( $bogo->post_excerpt );
@@ -92,19 +93,26 @@ class Bogo {
         $default = [
             'post_type'      => $this->post_type,
             'posts_per_page' => -1,
+            'paged'          => 1,
         ];
 
-        $args      = wp_parse_args( $args, $default );
-        $bogo_list = get_posts( $args );
-        $bogos     = [];
+        $args  = wp_parse_args( $args, $default );
+        $query = new WP_Query( $args );
+        $bogos = [];
 
-        foreach ( $bogo_list as $bogo ) {
-            $post_excerpt       = maybe_unserialize($bogo->post_excerpt);
+        foreach ( $query->posts as $bogo ) {
+            $post_excerpt       = maybe_unserialize( $bogo->post_excerpt );
             $post_excerpt['id'] = $bogo->ID;
             $bogos[]            = $post_excerpt;
         }
 
-        return $bogos;
+        return [
+            'data'         => $bogos,
+            'total_items'  => $query->found_posts,
+            'total_pages'  => $query->max_num_pages,
+            'current_page' => $args['paged'],
+            'per_page'     => $args['posts_per_page'],
+        ];
     }
 
     /**
@@ -118,10 +126,26 @@ class Bogo {
      * @return int|WP_Error
      */
     public function update( int $id, array $data ) {
+        $post = get_post( $id );
+
+        if ( ! $post ) {
+            return new WP_Error( 'bogo_not_found', __( 'BOGO offer not found.', 'storegrowth-sales-booster' ), [ 'status' => 404 ] );
+        }
+
+        // Get existing post_excerpt and unserialize.
+        $existing_data = maybe_unserialize( $post->post_excerpt );
+
+        if ( ! is_array( $existing_data ) ) {
+            $existing_data = [];
+        }
+
+        // Merge new data with existing.
+        $merged_data = array_merge( $existing_data, $data );
+
         $args = [
             'ID'           => $id,
-            'post_title'   => $data['name_of_order_bogo'] ?? '',
-            'post_excerpt' => maybe_serialize( $data ),
+            'post_title'   => $data['name_of_order_bogo'] ?? $post->post_title,
+            'post_excerpt' => maybe_serialize( $merged_data ),
         ];
 
         return wp_update_post( $args, true );
@@ -140,7 +164,7 @@ class Bogo {
         $result = wp_delete_post( $id, true );
 
         if ( ! $result ) {
-            return new WP_Error( 'delete_failed', 'Failed to delete Bogo' );
+            return new WP_Error( 'delete_failed', __( 'Failed to delete Bogo offer.', 'storegrowth-sales-booster' ) );
         }
 
         return true;
@@ -159,7 +183,7 @@ class Bogo {
     public function set_status( int $id, string $status ) {
         $bogo = get_post( $id );
         if ( ! $bogo || $bogo->post_type !== $this->post_type ) {
-            return new WP_Error( 'not_found', 'Bogo not found' );
+            return new WP_Error( 'not_found', __( 'Bogo not found', 'storegrowth-sales-booster' ) );
         }
 
         $bogo_settings                = ! empty( $bogo->post_excerpt ) ? maybe_unserialize( $bogo->post_excerpt ) : [];
@@ -185,11 +209,15 @@ class Bogo {
      */
     private function sanitize_create_bogo_data( array $data ) {
         $data['name_of_order_bogo']                 = $data['name_of_order_bogo'] ? sanitize_text_field( $data['name_of_order_bogo'] ) : '';
+
+        // todo: Need to correct the field names.
+        $data['offered_products']                   = $data['offered_products'] ? intval( $data['offered_products'] ) : 0; // Target product's ID.
+        $data['get_different_product_field']        = $data['get_different_product_field'] ? intval( $data['get_different_product_field'] ) : 0; // Offered product's ID.
+
         $data['target_products']                    = $data['target_products'] ? wc_clean( $data['target_products'] ) : [];
         $data['target_categories']                  = $data['target_categories'] ? wc_clean( $data['target_categories'] ) : [];
         $data['bogo_schedule']                      = ! empty( $data['bogo_schedule'] ) ? wc_clean( $data['bogo_schedule'] ) : [];
         $data['smart_offer']                        = $data['smart_offer'] ? sanitize_text_field( $data['smart_offer'] ) : '';
-        $data['get_different_product_field']        = $data['get_different_product_field'] ? intval( $data['get_different_product_field'] ) : 0;
         $data['offer_type']                         = $data['offer_type'] ? sanitize_text_field( $data['offer_type'] ) : '';
         $data['discount_amount']                    = $data['discount_amount'] ? sanitize_text_field( $data['discount_amount'] ) : '';
         $data['box_border_style']                   = $data['box_border_style'] ? sanitize_text_field( $data['box_border_style'] ) : '';

--- a/Includes/Modules/BoGo/Includes/OrderBogo.php
+++ b/Includes/Modules/BoGo/Includes/OrderBogo.php
@@ -166,11 +166,11 @@ class OrderBogo {
 		// Check offer dates
 		$current_date = date( 'Y-m-d' );
 		$is_pro       = is_plugin_active( 'storegrowth-sales-booster-pro/storegrowth-sales-booster-pro.php' );
-		if ( $is_pro && isset( $bogo_settings['offer_start'] ) && $current_date < $bogo_settings['offer_start'] ) {
+		if ( $is_pro && !empty( $bogo_settings['offer_start'] ) && $current_date < $bogo_settings['offer_start'] ) {
 			return false;
 		}
 
-		if ( $is_pro && isset( $bogo_settings['offer_end'] ) && $current_date > $bogo_settings['offer_end'] ) {
+		if ( $is_pro && !empty( $bogo_settings['offer_end'] ) && $current_date > $bogo_settings['offer_end'] ) {
 			return false;
 		}
 

--- a/Includes/Modules/BoGo/Includes/REST/BogoController.php
+++ b/Includes/Modules/BoGo/Includes/REST/BogoController.php
@@ -24,24 +24,24 @@ class BogoController extends WP_REST_Controller {
      *
      * @var Bogo
      */
-    private Bogo $bogo;
+    protected Bogo $bogo;
 
-	/**
-	 * Class Constructor.
-	 *
-	 * @return void
-	 */
+    /**
+     * Class Constructor.
+     *
+     * @return void
+     */
     public function __construct() {
-	    $this->namespace = 'sales-booster/v1';
-	    $this->rest_base = 'bogo/offers';
+        $this->namespace = 'sales-booster/v1';
+        $this->rest_base = 'bogo/offers';
         $this->bogo      = new Bogo();
     }
 
-	/**
-	 * Register Rest Routes.
-	 *
-	 * @return void
-	 */
+    /**
+     * Register Rest Routes.
+     *
+     * @return void
+     */
     public function register_routes(): void {
         register_rest_route(
             $this->namespace,
@@ -130,15 +130,15 @@ class BogoController extends WP_REST_Controller {
         );
     }
 
-	/**
-	 * Get Items.
-	 *
-	 * @since 1.29.0
-	 *
-	 * @param WP_REST_Request $request Rest Request.
-	 *
-	 * @return WP_Error|WP_HTTP_Response|WP_REST_Response
-	 */
+    /**
+     * Get Items.
+     *
+     * @since 1.29.0
+     *
+     * @param WP_REST_Request $request Rest Request.
+     *
+     * @return WP_Error|WP_HTTP_Response|WP_REST_Response
+     */
     public function get_items( $request ) {
         $params = $request->get_params();
 
@@ -164,15 +164,15 @@ class BogoController extends WP_REST_Controller {
         return $this->format_collection_response( $response, $request, $items['total_items'] );
     }
 
-	/**
-	 * Get Item.
-	 *
-	 * @since 1.29.0
-	 *
-	 * @param WP_REST_Request $request Rest Request.
-	 *
-	 * @return WP_Error|WP_HTTP_Response|WP_REST_Response
-	 */
+    /**
+     * Get Item.
+     *
+     * @since 1.29.0
+     *
+     * @param WP_REST_Request $request Rest Request.
+     *
+     * @return WP_Error|WP_HTTP_Response|WP_REST_Response
+     */
     public function get_item( $request ) {
         $id   = $request->get_param( 'id' );
         $item = $this->bogo->get_item( $id );
@@ -226,15 +226,15 @@ class BogoController extends WP_REST_Controller {
         return $response;
     }
 
-	/**
-	 * Update item.
-	 *
-	 * @since 1.29.0
-	 *
-	 * @param WP_REST_Request $request The REST request.
-	 *
-	 * @return WP_REST_Response
-	 */
+    /**
+     * Update item.
+     *
+     * @since 1.29.0
+     *
+     * @param WP_REST_Request $request The REST request.
+     *
+     * @return WP_REST_Response
+     */
     public function update_item( $request ) {
         $id   = $request->get_param( 'id' );
         $data = $request->get_params();
@@ -258,15 +258,15 @@ class BogoController extends WP_REST_Controller {
         return $response;
     }
 
-	/**
-	 * Delete item.
-	 *
-	 * @since 1.29.0
-	 *
-	 * @param WP_REST_Request $request The REST request.
-	 *
-	 * @return WP_REST_Response
-	 */
+    /**
+     * Delete item.
+     *
+     * @since 1.29.0
+     *
+     * @param WP_REST_Request $request The REST request.
+     *
+     * @return WP_REST_Response
+     */
     public function delete_item( $request ) {
         $id     = $request->get_param( 'id' );
         $result = $this->bogo->delete( $id );
@@ -278,13 +278,13 @@ class BogoController extends WP_REST_Controller {
         return new WP_REST_Response( [ 'deleted' => true ], 200 );
     }
 
-	/**
-	 * Get Endpoint Args for Create Item.
-	 *
-	 * @since 1.29.0
-	 *
-	 * @return array
-	 */
+    /**
+     * Get Endpoint Args for Create Item.
+     *
+     * @since 1.29.0
+     *
+     * @return array
+     */
     public function get_endpoint_args_for_create_item() {
         return [
             'name_of_order_bogo' => [
@@ -676,7 +676,7 @@ class BogoController extends WP_REST_Controller {
         $max_pages = ceil( $total_items / $per_page );
 
         $response->header( 'X-WP-TotalPages', (int) $max_pages );
-        $base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->base ) ) );
+        $base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
 
         if ( $page > 1 ) {
             $prev_page = $page - 1;

--- a/Includes/Modules/BoGo/Includes/REST/BogoController.php
+++ b/Includes/Modules/BoGo/Includes/REST/BogoController.php
@@ -1,0 +1,973 @@
+<?php
+
+namespace STOREGROWTH\SPSB\Modules\BoGo\Includes\REST;
+
+use WP_Error;
+use WP_HTTP_Response;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use STOREGROWTH\SPSB\Modules\BoGo\Includes\Bogo;
+
+defined( 'ABSPATH' ) || exit();
+
+/**
+ * BogoController Class.
+ *
+ * @package SBFW
+ */
+class BogoController extends WP_REST_Controller {
+
+    /**
+     * Bogo instance.
+     *
+     * @var Bogo
+     */
+    private Bogo $bogo;
+
+	/**
+	 * Class Constructor.
+	 *
+	 * @return void
+	 */
+    public function __construct() {
+	    $this->namespace = 'sales-booster/v1';
+	    $this->rest_base = 'bogo/offers';
+        $this->bogo      = new Bogo();
+    }
+
+	/**
+	 * Register Rest Routes.
+	 *
+	 * @return void
+	 */
+    public function register_routes(): void {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            [
+                [
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => [ $this, 'get_items' ],
+                    'permission_callback' => [ $this, 'check_permission' ],
+                    'args'                => $this->get_collection_params(),
+                ],
+                [
+                    'methods'             => WP_REST_Server::CREATABLE,
+                    'callback'            => [ $this, 'create_item' ],
+                    'permission_callback' => [ $this, 'check_permission' ],
+                    'args'                => $this->get_endpoint_args_for_create_item(),
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base . '/(?P<id>\d+)',
+            [
+                'args' => [
+                    'id' => [
+                        'description' => __( 'Bogo offer ID', 'dokan' ),
+                        'type'        => 'integer',
+                    ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => [ $this, 'get_item' ],
+                    'permission_callback' => [ $this, 'check_permission' ],
+                    'args'                => [
+                        'id' => [
+                            'type'     => 'integer',
+                            'required' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::EDITABLE,
+                    'callback'            => [ $this, 'update_item' ],
+                    'permission_callback' => [ $this, 'check_permission' ],
+                    'args'                => [
+                        'id' => [
+                            'type'     => 'integer',
+                            'required' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::DELETABLE,
+                    'callback'            => [ $this, 'delete_item' ],
+                    'permission_callback' => [ $this, 'check_permission' ],
+                    'args'                => [
+                        'id' => [
+                            'type'     => 'integer',
+                            'required' => true,
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Permission Checker.
+     *
+     * @since 1.29.0
+     *
+     * @param WP_REST_Request $request Rest Request.
+     *
+     * @return bool|WP_Error
+     */
+    public function check_permission( $request ) {
+        if ( current_user_can( 'manage_options' ) ) {
+            return true;
+        }
+
+        return new WP_Error(
+            'salesbooster_permission_failure',
+            __( 'Sorry! You are not permitted to do the current action.', 'storegrowth-sales-booster' ),
+            [ 'status' => 403 ]
+        );
+    }
+
+	/**
+	 * Get Items.
+	 *
+	 * @since 1.29.0
+	 *
+	 * @param WP_REST_Request $request Rest Request.
+	 *
+	 * @return WP_Error|WP_HTTP_Response|WP_REST_Response
+	 */
+    public function get_items( $request ) {
+        $params = $request->get_params();
+
+        $args = [
+            'posts_per_page' => $params['per_page'],
+            'paged'          => $params['page'],
+        ];
+
+        $items = $this->bogo->get_items( $args );
+
+        if ( ! $items['data'] ) {
+            return new WP_Error( 'no_offer_items', __( 'No BOGO offers found.', 'storegrowth-sales-booster' ), [ 'status' => 404 ] );
+        }
+
+        $data = [];
+        foreach ( $items['data'] as $item ) {
+            $item_data = $this->prepare_item_for_response( $item, $request );
+            $data[]    = $this->prepare_response_for_collection( $item_data );
+        }
+
+        $response = rest_ensure_response( $data );
+
+        return $this->format_collection_response( $response, $request, $items['total_items'] );
+    }
+
+	/**
+	 * Get Item.
+	 *
+	 * @since 1.29.0
+	 *
+	 * @param WP_REST_Request $request Rest Request.
+	 *
+	 * @return WP_Error|WP_HTTP_Response|WP_REST_Response
+	 */
+    public function get_item( $request ) {
+        $id   = $request->get_param( 'id' );
+        $item = $this->bogo->get_item( $id );
+
+        if ( is_wp_error( $item ) ) {
+            return new WP_REST_Response( [ 'error' => $item->get_error_message() ], 404 );
+        }
+
+        $response = $this->prepare_item_for_response( $item, $request );
+        $response->set_status( 200 );
+
+        return $response;
+    }
+
+    /**
+     * Create item.
+     *
+     * @since 1.29.0
+     *
+     * @param WP_REST_Request $request The REST request.
+     *
+     * @return WP_REST_Response
+     */
+    public function create_item( $request ) {
+        $data = $request->get_params();
+
+        if ( empty( $data ) || ! is_array( $data ) ) {
+            return new WP_REST_Response( [ 'error' => __( 'No data provided', 'storegrowth-sales-booster-pro' ) ], 400 );
+        }
+
+        $result = $this->bogo->create( $data );
+
+        if ( is_wp_error( $result ) ) {
+            return new WP_REST_Response( [ 'error' => $result->get_error_message() ], 400 );
+        }
+
+        if ( empty( $result ) || ! is_int( $result ) ) {
+            // Likely due to free version restriction, return appropriate message.
+            return new WP_REST_Response(
+                [ 'error' => __( 'BOGO limit exceeded. Upgrade to PRO for unlimited offers.', 'storegrowth-sales-booster-pro' ) ],
+                403
+            );
+        }
+
+        $post         = get_post( $result );
+        $created_data = $this->bogo->get_item( $post->ID );
+        $response     = $this->prepare_item_for_response( $created_data, $request );
+
+        $response->set_status( 201 );
+
+        return $response;
+    }
+
+	/**
+	 * Update item.
+	 *
+	 * @since 1.29.0
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 *
+	 * @return WP_REST_Response
+	 */
+    public function update_item( $request ) {
+        $id   = $request->get_param( 'id' );
+        $data = $request->get_params();
+
+        if ( empty( $data ) || ! is_array( $data ) ) {
+            return new WP_REST_Response( [ 'error' => __( 'No data provided', 'storegrowth-sales-booster-pro' ) ], 400 );
+        }
+
+        $result = $this->bogo->update( $id, $data );
+
+        if ( is_wp_error( $result ) ) {
+            return new WP_REST_Response( [ 'error' => $result->get_error_message() ], 400 );
+        }
+
+        $post         = get_post( $result );
+        $created_data = $this->bogo->get_item( $post->ID );
+        $response     = $this->prepare_item_for_response( $created_data, $request );
+
+        $response->set_status( 201 );
+
+        return $response;
+    }
+
+	/**
+	 * Delete item.
+	 *
+	 * @since 1.29.0
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 *
+	 * @return WP_REST_Response
+	 */
+    public function delete_item( $request ) {
+        $id     = $request->get_param( 'id' );
+        $result = $this->bogo->delete( $id );
+
+        if ( is_wp_error( $result ) ) {
+            return new WP_REST_Response( [ 'error' => $result->get_error_message() ], 400 );
+        }
+
+        return new WP_REST_Response( [ 'deleted' => true ], 200 );
+    }
+
+	/**
+	 * Get Endpoint Args for Create Item.
+	 *
+	 * @since 1.29.0
+	 *
+	 * @return array
+	 */
+    public function get_endpoint_args_for_create_item() {
+        return [
+            'name_of_order_bogo' => [
+                'type'              => 'string',
+                'required'          => true,
+                'description'       => __( 'Name of the BOGO offer.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'offered_products' => [
+                'type'              => 'integer',
+                'required'          => true,
+                'description'       => __( 'The ID of target product.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'absint',
+            ],
+            'get_different_product_field' => [
+                'type'              => 'integer',
+                'required'          => true,
+                'description'       => __( 'ID of the offered product.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'absint',
+            ],
+            'bogo_status' => [
+                'type'              => 'string',
+                'default'           => 'yes',
+                'enum'              => [ 'yes', 'no' ],
+                'description'       => __( 'Whether the BOGO is enabled.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'bogo_deal_type' => [
+                'type'              => 'string',
+                'default'           => 'different',
+                'enum'              => [ 'same', 'different' ],
+                'description'       => __( 'Type of BOGO deal.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'offer_type' => [
+                'type'              => 'string',
+                'required'          => true,
+                'description'       => __( 'Offer types: free, discount.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'discount_amount' => [
+                'type'              => 'string',
+                'description'       => __( 'Discount value or percentage.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'bogo_type' => [
+                'type'              => 'string',
+                'default'           => 'products',
+                'enum'              => [ 'products', 'categories' ],
+                'description'       => __( 'Whether the BOGO applies to products or categories.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'minimum_quantity_required' => [
+                'type'              => 'integer',
+                'default'           => 1,
+                'description'       => __( 'Minimum quantity required to trigger the offer.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'absint',
+            ],
+            'offer_start_date' => [
+                'type'              => 'string',
+                'format'            => 'date-time',
+                'description'       => __( 'Offer start date.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'offer_end_date' => [
+                'type'              => 'string',
+                'format'            => 'date-time',
+                'description'       => __( 'Offer end date.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'default_badge_icon_name' => [
+                'type'              => 'string',
+                'default'           => 'bogo-icons-1',
+                'description'       => __( 'Default badge icon name.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'enable_custom_badge_image' => [
+                'type'              => 'boolean',
+                'default'           => false,
+                'description'       => __( 'Enable custom badge image.', 'storegrowth-sales-booster' ),
+                'validate_callback' => 'rest_validate_request_arg',
+            ],
+            'default_custom_badge_icon' => [
+                'type'              => 'string',
+                'description'       => __( 'Custom badge image URL or ID.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'esc_url_raw',
+            ],
+            'target_products' => [
+                'type'              => 'string',
+                'description'       => __( 'Comma-separated target product IDs.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'target_categories' => [
+                'type'        => 'array',
+                'items'       => [ 'type' => 'integer' ],
+                'description' => __( 'Target category IDs.', 'storegrowth-sales-booster' ),
+                'validate_callback' => 'rest_validate_request_arg',
+            ],
+            'get_alternate_products' => [
+                'type'        => 'array',
+                'items'       => [ 'type' => 'integer' ],
+                'description' => __( 'Alternate product IDs for GET BOGO type.', 'storegrowth-sales-booster' ),
+                'validate_callback' => 'rest_validate_request_arg',
+            ],
+            'get_alternate_categories' => [
+                'type'        => 'array',
+                'items'       => [ 'type' => 'integer' ],
+                'description' => __( 'Alternate category IDs for GET BOGO type.', 'storegrowth-sales-booster' ),
+                'validate_callback' => 'rest_validate_request_arg',
+            ],
+            'exclude_products' => [
+                'type'        => 'array',
+                'items'       => [ 'type' => 'integer' ],
+                'description' => __( 'Product IDs to exclude.', 'storegrowth-sales-booster' ),
+                'validate_callback' => 'rest_validate_request_arg',
+            ],
+            'offer_schedule' => [
+                'type'        => 'array',
+                'items'       => [ 'type' => 'string' ],
+                'description' => __( 'Offer schedule types (e.g., daily).', 'storegrowth-sales-booster' ),
+            ],
+            'smart_offer' => [
+                'type'              => 'boolean',
+                'default'           => false,
+                'description'       => __( 'Enable smart offer logic.', 'storegrowth-sales-booster' ),
+                'validate_callback' => 'rest_validate_request_arg',
+            ],
+            'box_border_style' => [
+                'type'              => 'string',
+                'description'       => __( 'Border style for display box.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'box_border_color' => [
+                'type'              => 'string',
+                'description'       => __( 'Box border color.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_hex_color',
+            ],
+            'box_top_margin' => [
+                'type'              => 'integer',
+                'description'       => __( 'Top margin for the box.', 'storegrowth-sales-booster' ),
+                'validate_callback' => 'rest_validate_request_arg',
+            ],
+            'box_bottom_margin' => [
+                'type'              => 'integer',
+                'description'       => __( 'Bottom margin for the box.', 'storegrowth-sales-booster' ),
+                'validate_callback' => 'rest_validate_request_arg',
+            ],
+            'discount_background_color' => [
+                'type'              => 'string',
+                'description'       => __( 'Background color for discount text.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_hex_color',
+            ],
+            'discount_text_color' => [
+                'type'              => 'string',
+                'description'       => __( 'Color of discount text.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_hex_color',
+            ],
+            'discount_font_size' => [
+                'type'              => 'string',
+                'description'       => __( 'Font size for discount text.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'product_description_text_color' => [
+                'type'              => 'string',
+                'description'       => __( 'Color of product description text.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_hex_color',
+            ],
+            'product_description_font_size' => [
+                'type'              => 'string',
+                'description'       => __( 'Font size of product description text.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'accept_offer_background_color' => [
+                'type'              => 'string',
+                'description'       => __( 'Background color for accept offer button.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_hex_color',
+            ],
+            'accept_offer_text_color' => [
+                'type'              => 'string',
+                'description'       => __( 'Text color for accept offer.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_hex_color',
+            ],
+            'accept_offer_font_size' => [
+                'type'              => 'string',
+                'description'       => __( 'Font size for accept offer.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'offer_description_background_color' => [
+                'type'              => 'string',
+                'description'       => __( 'Background color for offer description.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_hex_color',
+            ],
+            'offer_description_text_color' => [
+                'type'              => 'string',
+                'description'       => __( 'Text color for offer description.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_hex_color',
+            ],
+            'offer_description_font_size' => [
+                'type'              => 'string',
+                'description'       => __( 'Font size for offer description.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'offer_image_url' => [
+                'type'              => 'string',
+                'description'       => __( 'Image URL for the offer.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'esc_url_raw',
+            ],
+            'offer_product_title' => [
+                'type'              => 'string',
+                'description'       => __( 'Title shown for the offered product.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'offer_product_id' => [
+                'type'              => 'integer',
+                'description'       => __( 'Product ID of the offered product.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'absint',
+            ],
+            'offer_discount_title' => [
+                'type'              => 'string',
+                'description'       => __( 'Discount title shown on frontend.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'offer_fixed_price_title' => [
+                'type'              => 'string',
+                'description'       => __( 'Fixed price title for offer.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'product_description' => [
+                'type'              => 'string',
+                'description'       => __( 'Product description shown on the offer.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_textarea_field',
+            ],
+            'selection_title' => [
+                'type'              => 'string',
+                'description'       => __( 'Title for product selection.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+            'offer_description' => [
+                'type'              => 'string',
+                'description'       => __( 'Detailed offer description.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_textarea_field',
+            ],
+            'offer_product_regular_price' => [
+                'type'              => 'number',
+                'description'       => __( 'Regular price of the offered product.', 'storegrowth-sales-booster' ),
+                'validate_callback' => 'rest_validate_request_arg',
+            ],
+            'product_page_message' => [
+                'type'              => 'string',
+                'description'       => __( 'Message shown on product page.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_textarea_field',
+            ],
+            'shop_page_message' => [
+                'type'              => 'string',
+                'description'       => __( 'Message shown on shop page.', 'storegrowth-sales-booster' ),
+                'sanitize_callback' => 'sanitize_textarea_field',
+            ],
+        ];
+    }
+
+    /**
+     * Prepare Item for The REST API Response.
+     *
+     * @since 1.29.0
+     *
+     * @param array            $item    BOGO offer data.
+     * @param WP_REST_Request  $request Request object.
+     *
+     * @return WP_REST_Response
+     */
+    public function prepare_item_for_response( $item, $request ) {
+        $fields = $this->get_fields_for_response( $request );
+        $data   = [];
+
+        // Simple field map: field => transformation callback (optional)
+        $field_map = [
+            'id'                          => 'absint',
+            'name_of_order_bogo'          => 'html_entity_decode',
+            'offered_products'            => 'absint',
+            'get_different_product_field' => 'absint',
+            'bogo_status'              => null,
+            'bogo_deal_type'           => null,
+            'bogo_type'                => null,
+            'minimum_quantity_required'=> null,
+            'offer_start_date'         => null,
+            'offer_end_date'           => null,
+            'default_badge_icon_name'  => null,
+            'enable_custom_badge_image'=> null,
+            'default_custom_badge_icon'=> null,
+            'offer_type'               => null,
+            'discount_amount'          => null,
+            'box_border_style'         => null,
+            'box_border_color'         => null,
+            'box_top_margin'           => null,
+            'box_bottom_margin'        => null,
+            'discount_background_color'=> null,
+            'discount_text_color'      => null,
+            'discount_font_size'       => null,
+            'product_description_text_color' => null,
+            'product_description_font_size'  => null,
+            'accept_offer_background_color'  => null,
+            'accept_offer_text_color'        => null,
+            'accept_offer_font_size'         => null,
+            'offer_description_background_color' => null,
+            'offer_description_text_color'       => null,
+            'offer_description_font_size'        => null,
+            'offer_image_url'           => 'esc_url_raw',
+            'offer_product_title'       => null,
+            'offer_product_id'          => 'absint',
+            'offer_discount_title'      => 'html_entity_decode',
+            'offer_fixed_price_title'   => 'html_entity_decode',
+            'product_description'       => 'html_entity_decode',
+            'selection_title'           => 'html_entity_decode',
+            'offer_description'         => 'html_entity_decode',
+            'offer_product_regular_price' => null,
+            'product_page_message'      => null,
+            'shop_page_message'         => null,
+            'offer_start'               => null,
+            'offer_end'                 => null,
+            'smart_offer'               => function( $v ) { return $v === 'true'; },
+        ];
+
+        // Always-cast arrays
+        $array_fields = [
+            'offer_schedule',
+            'target_products',
+            'target_categories',
+            'bogo_schedule',
+            'get_alternate_products',
+        ];
+
+        foreach ( $field_map as $key => $callback ) {
+            if ( in_array( $key, $fields, true ) && isset( $item[ $key ] ) ) {
+                $value = $item[ $key ];
+
+                if ( is_callable( $callback ) ) {
+                    $data[ $key ] = call_user_func( $callback, $value );
+                } else {
+                    $data[ $key ] = $value;
+                }
+            }
+        }
+
+        foreach ( $array_fields as $array_key ) {
+            if ( in_array( $array_key, $fields, true ) && isset( $item[ $array_key ] ) ) {
+                $data[ $array_key ] = (array) $item[ $array_key ];
+            }
+        }
+
+        // Prepare response with context and additional fields
+        $context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+        $data     = $this->filter_response_by_context( $data, $context );
+        $data     = $this->add_additional_fields_to_object( $data, $request );
+        $response = rest_ensure_response( $data );
+
+        /**
+         * Filter the prepared BOGO response.
+         *
+         * @param WP_REST_Response $response The response object.
+         * @param array            $item     Original item array.
+         * @param WP_REST_Request  $request  Request object.
+         */
+        return apply_filters( 'storegrowth_rest_prepare_bogo_offer', $response, $item, $request );
+    }
+
+
+    /**
+     * Format item's collection for response
+     *
+     * @since 1.29.0
+     *
+     * @param  WP_REST_Response $response
+     * @param  WP_REST_Request  $request
+     * @param  int              $total_items
+     *
+     * @return WP_REST_Response
+     */
+    public function format_collection_response( $response, $request, $total_items ) {
+        if ( intval( $total_items ) === 0 ) {
+            return $response;
+        }
+
+        // Store pagination values for headers then unset for count query.
+        $per_page = (int) ( ! empty( $request['per_page'] ) ? $request['per_page'] : 20 );
+        $page     = (int) ( ! empty( $request['page'] ) ? $request['page'] : 1 );
+
+        $response->header( 'X-WP-Total', (int) $total_items );
+
+        $max_pages = ceil( $total_items / $per_page );
+
+        $response->header( 'X-WP-TotalPages', (int) $max_pages );
+        $base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->base ) ) );
+
+        if ( $page > 1 ) {
+            $prev_page = $page - 1;
+            if ( $prev_page > $max_pages ) {
+                $prev_page = $max_pages;
+            }
+            $prev_link = add_query_arg( 'page', $prev_page, $base );
+            $response->link_header( 'prev', $prev_link );
+        }
+        if ( $max_pages > $page ) {
+            $next_page = $page + 1;
+            $next_link = add_query_arg( 'page', $next_page, $base );
+            $response->link_header( 'next', $next_link );
+        }
+
+        return $response;
+    }
+
+    /**
+     * Get The Item Schema.
+     *
+     * @since 1.29.0
+     *
+     * @return array
+     */
+    public function get_item_schema() {
+        return [
+            '$schema'    => 'http://json-schema.org/draft-04/schema#',
+            'title'      => 'storegrowth_bogo_offer',
+            'type'       => 'object',
+            'properties' => [
+                'id' => [
+                    'description' => __( 'Unique identifier for the BOGO offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'integer',
+                    'context'     => [ 'view', 'edit' ],
+                    'readonly'    => true,
+                ],
+                'name_of_order_bogo' => [
+                    'description' => __( 'The internal name of the BOGO offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offered_products' => [
+                    'description' => __( 'The ID of target product.', 'storegrowth-sales-booster' ),
+                    'type'        => 'integer',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'bogo_status' => [
+                    'description' => __( 'Whether the BOGO offer is active.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'enum'        => [ 'yes', 'no' ],
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'bogo_deal_type' => [
+                    'description' => __( 'The deal type for BOGO (e.g., same or different products).', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'bogo_type' => [
+                    'description' => __( 'The target type of the BOGO deal, such as products or categories.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'minimum_quantity_required' => [
+                    'description' => __( 'Minimum quantity required to trigger the BOGO offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_start_date' => [
+                    'description' => __( 'The formatted start date of the BOGO offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'format'      => 'date',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_end_date' => [
+                    'description' => __( 'The formatted end date of the BOGO offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'format'      => 'date',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_start' => [
+                    'description' => __( 'The start date in YYYY-MM-DD format.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'format'      => 'date',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_end' => [
+                    'description' => __( 'The end date in YYYY-MM-DD format.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'format'      => 'date',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'target_products' => [
+                    'description' => __( 'Array of product IDs eligible for BOGO.', 'storegrowth-sales-booster' ),
+                    'type'        => 'array',
+                    'items'       => [ 'type' => 'integer' ],
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'target_categories' => [
+                    'description' => __( 'Array of category IDs eligible for BOGO.', 'storegrowth-sales-booster' ),
+                    'type'        => 'array',
+                    'items'       => [ 'type' => 'integer' ],
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_schedule' => [
+                    'description' => __( 'Recurring schedule settings for the offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'array',
+                    'items'       => [ 'type' => 'string' ],
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'smart_offer' => [
+                    'description' => __( 'Whether the offer is a smart (dynamic) offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'enum'        => [ 'true', 'false' ],
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'get_different_product_field' => [
+                    'description' => __( 'ID of the offered product.', 'storegrowth-sales-booster' ),
+                    'type'        => 'integer',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'get_alternate_products' => [
+                    'description' => __( 'Array of alternate product IDs for the offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'array',
+                    'items'       => [ 'type' => 'string' ],
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_type' => [
+                    'description' => __( 'Type of benefit offered (free, fixed price, etc.).', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'discount_amount' => [
+                    'description' => __( 'Amount of discount applied in the offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'default_badge_icon_name' => [
+                    'description' => __( 'Name of the default badge icon.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'enable_custom_badge_image' => [
+                    'description' => __( 'Whether a custom badge image is enabled (0 or 1).', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'enum'        => [ '0', '1' ],
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'default_custom_badge_icon' => [
+                    'description' => __( 'URL or path to the custom badge image.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'box_border_style' => [
+                    'description' => __( 'CSS style for box border (e.g., solid, dashed).', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'box_border_color' => [
+                    'description' => __( 'Color code of the border.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'box_top_margin' => [
+                    'description' => __( 'Top margin value of the BOGO box.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'box_bottom_margin' => [
+                    'description' => __( 'Bottom margin value of the BOGO box.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'discount_background_color' => [
+                    'description' => __( 'Background color of the discount box.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'discount_text_color' => [
+                    'description' => __( 'Text color for discount information.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'discount_font_size' => [
+                    'description' => __( 'Font size for discount text.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'product_description_text_color' => [
+                    'description' => __( 'Text color for product descriptions.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'product_description_font_size' => [
+                    'description' => __( 'Font size for product descriptions.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'accept_offer_background_color' => [
+                    'description' => __( 'Background color of the "Accept Offer" button.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'accept_offer_text_color' => [
+                    'description' => __( 'Text color of the "Accept Offer" button.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'accept_offer_font_size' => [
+                    'description' => __( 'Font size for the "Accept Offer" button text.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_description_background_color' => [
+                    'description' => __( 'Background color for the offer description box.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_description_text_color' => [
+                    'description' => __( 'Text color for the offer description.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_description_font_size' => [
+                    'description' => __( 'Font size of the offer description text.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_image_url' => [
+                    'description' => __( 'URL to the promotional image or icon.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'format'      => 'uri',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_product_title' => [
+                    'description' => __( 'Title of the offered product.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_product_id' => [
+                    'description' => __( 'Product ID for the offered product.', 'storegrowth-sales-booster' ),
+                    'type'        => 'integer',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_discount_title' => [
+                    'description' => __( 'Title shown for the discount.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_fixed_price_title' => [
+                    'description' => __( 'Title for fixed-price deals.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'product_description' => [
+                    'description' => __( 'Short description for the offer product.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'selection_title' => [
+                    'description' => __( 'Title shown during offer product selection.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_description' => [
+                    'description' => __( 'The long description of the BOGO offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'offer_product_regular_price' => [
+                    'description' => __( 'Regular price of the offered product.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'product_page_message' => [
+                    'description' => __( 'Message shown on the product page for the offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'shop_page_message' => [
+                    'description' => __( 'Message shown on the shop page for the offer.', 'storegrowth-sales-booster' ),
+                    'type'        => 'string',
+                    'context'     => [ 'view', 'edit' ],
+                ],
+                'bogo_schedule' => [
+                    'description' => __( 'Schedule configuration for offers.', 'storegrowth-sales-booster' ),
+                    'type'        => 'array',
+                    'items'       => [ 'type' => 'string' ],
+                    'context'     => [ 'view', 'edit' ],
+                ],
+            ],
+        ];
+    }
+}

--- a/Includes/Modules/BoGo/Includes/REST/BogoController.php
+++ b/Includes/Modules/BoGo/Includes/REST/BogoController.php
@@ -68,7 +68,7 @@ class BogoController extends WP_REST_Controller {
             [
                 'args' => [
                     'id' => [
-                        'description' => __( 'Bogo offer ID', 'dokan' ),
+                        'description' => __( 'Bogo offer ID', 'storegrowth-sales-booster' ),
                         'type'        => 'integer',
                     ],
                 ],

--- a/Includes/Modules/BoGo/Includes/REST/BogoController.php
+++ b/Includes/Modules/BoGo/Includes/REST/BogoController.php
@@ -343,13 +343,13 @@ class BogoController extends WP_REST_Controller {
                 'description'       => __( 'Minimum quantity required to trigger the offer.', 'storegrowth-sales-booster' ),
                 'sanitize_callback' => 'absint',
             ],
-            'offer_start_date' => [
+            'offer_start' => [
                 'type'              => 'string',
                 'format'            => 'date-time',
                 'description'       => __( 'Offer start date.', 'storegrowth-sales-booster' ),
                 'sanitize_callback' => 'sanitize_text_field',
             ],
-            'offer_end_date' => [
+            'offer_end' => [
                 'type'              => 'string',
                 'format'            => 'date-time',
                 'description'       => __( 'Offer end date.', 'storegrowth-sales-booster' ),

--- a/Includes/Modules/BoGo/Includes/REST/BogoController.php
+++ b/Includes/Modules/BoGo/Includes/REST/BogoController.php
@@ -301,8 +301,8 @@ class BogoController extends WP_REST_Controller {
             ],
             'get_different_product_field' => [
                 'type'              => 'integer',
-                'required'          => true,
                 'description'       => __( 'ID of the offered product.', 'storegrowth-sales-booster' ),
+                'default'           => 0,
                 'sanitize_callback' => 'absint',
             ],
             'bogo_status' => [

--- a/Includes/Modules/BoGo/assets/src/components/BogoTabLayout.jsx
+++ b/Includes/Modules/BoGo/assets/src/components/BogoTabLayout.jsx
@@ -44,13 +44,18 @@ function BogoTabLayout({ navigate, useSearchParams }) {
     },
   ];
 
+  const filteredTabPanels = applyFilters(
+    'sgsb_bogo_tab_panels',
+    tabPanels
+  );
+
   return (
     <>
       <Form {...layout}>
         <PanelRow>
           <PanelSettings
             colSpan={24}
-            tabPanels={tabPanels}
+            tabPanels={filteredTabPanels}
             changeHandler={changeTab}
             activeTab={tabName ? tabName : "general"}
           />

--- a/Includes/Modules/BoGo/assets/src/store.js
+++ b/Includes/Modules/BoGo/assets/src/store.js
@@ -8,6 +8,7 @@ const DEFAULT_STATE = {
   createBogoForm,
   bogo_data: [],
   bogoGeneralSettings: iniBogoGlobalSettings,
+  extensionData: {},
 };
 
 /**
@@ -31,6 +32,15 @@ const reducer = (state = DEFAULT_STATE, action) => {
       return {
         ...state,
         bogoGeneralSettings: action.payload,
+      };
+
+    case "UPDATE_EXTENSION_DATA":
+      return {
+        ...state,
+        extensionData: {
+          ...state.extensionData,
+          ...action.payload, // Merge new data into existing
+        },
       };
 
     default:
@@ -82,6 +92,13 @@ const actions = {
       payload: iniBogoGlobalSettings, // Reset to initial bogoGlobalSettings
     };
   },
+
+  setExtensionData(payload) {
+    return {
+      type: "UPDATE_EXTENSION_DATA",
+      payload,
+    };
+  },
 };
 
 /**
@@ -96,6 +113,9 @@ const selectors = {
   },
   getBogoGlobalSettings(state) {
     return state.bogoGeneralSettings;
+  },
+  getExtensionData(state) {
+    return state.extensionData;
   },
 };
 


### PR DESCRIPTION
* Related Pro PR: https://github.com/getdokan/storegrowth-sales-booster-pro/pull/93

* Closes: https://github.com/getdokan/dokan-pro/issues/4324


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added REST API endpoints for managing Buy One Get One (BOGO) offers, enabling creation, retrieval, updating, and deletion via external integrations.
  * Introduced advanced management of BOGO offers, including offer creation limits, detailed scheduling, and status updates.
  * Enhanced the Redux store with extensible data support for future integrations and plugin extensions.
  * Enabled external modification of BOGO tab panels in the interface through a filter mechanism.

* **Bug Fixes**
  * Improved date validation for BOGO offer applicability, ensuring offers only activate when valid start and end dates are provided.

* **Refactor**
  * Centralized BOGO offer operations for more consistent error handling and data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->