### PR TITLE
fix: update YouTube link in Ready component

### DIFF
--- a/assets/src/components/initail-setup/Ready.jsx
+++ b/assets/src/components/initail-setup/Ready.jsx
@@ -14,7 +14,7 @@ const Ready = () => {
           </div>
           <div className="social-links">
             <a
-              href="https://www.youtube.com/@Invizo-io"
+              href="https://www.youtube.com/playlist?list=PLJorZsV2RVv9t0NTRb27PoS0pUkywfowX"
               target="_blank"
               className="social-link youtube"
               onClick={null}


### PR DESCRIPTION
### Fix: Update YouTube link in `Ready` component

**What changed**

* Replaced outdated YouTube link with the correct one in the `Ready` component.

**Why this change**

* The previous link was incorrect/outdated.
* Ensures users are directed to the intended video resource.

### Closes: https://github.com/getdokan/storegrowth-sales-booster-pro/issues/105

**Testing**

* Verified updated link renders correctly in the component.
* Click tested to confirm it opens the correct video.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the YouTube social link in the Ready step of the initial setup to open a playlist URL instead of the channel.
  - The link text/icon and surrounding layout remain unchanged; only the destination was modified.
  - No other user-facing behavior or settings were altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->