### PR TITLE
fix: conditionally render pagination component based on total items and items per page

### DIFF
--- a/assets/src/components/modules/Modules.js
+++ b/assets/src/components/modules/Modules.js
@@ -282,22 +282,24 @@ function Modules() {
           minValue={minValue}
           maxValue={maxValue}
         />
-        <div
-          className="sgsb__module-pagination"
-          style={{
-            paddingTop: "80px",
-            paddingLeft: "22px",
-          }}
-        >
-          <Pagination
-            defaultCurrent={1}
-            current={currentPage}
-            defaultPageSize={perPageItem}
-            onChange={hanglePageItem}
-            total={totalItems}
-            hideOnSinglePage={false}
-          />
-        </div>
+        {totalItems > perPageItem && (
+          <div
+            className="sgsb__module-pagination"
+            style={{
+              paddingTop: "80px",
+              paddingLeft: "22px",
+            }}
+          >
+            <Pagination
+              defaultCurrent={1}
+              current={currentPage}
+              defaultPageSize={perPageItem}
+              onChange={hanglePageItem}
+              total={totalItems}
+              hideOnSinglePage={false}
+            />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
This PR updates the pagination component to render only when necessary. Pagination now appears only when the total number of items exceeds 6 (items per page) on the active module page

###closes: https://github.com/getdokan/storegrowth-sales-booster-pro/issues/122

What was fixed

Before: Pagination always appeared, even when there were 6 or fewer items.

After: Pagination appears only if total items > 6.

Why is this change needed

Displaying pagination when all items fit on one page creates unnecessary clutter and confusion. This fix ensures a cleaner, more intuitive UI.

Testing steps

Add 6 or fewer items → Pagination should not appear on the active modules page
Add more than 6 items → Pagination should appear correctly.