### PR TITLE
refactor: remove pagination from module list and related components

### DIFF
--- a/assets/src/components/initail-setup/ModulesSetup.jsx
+++ b/assets/src/components/initail-setup/ModulesSetup.jsx
@@ -1,49 +1,16 @@
 import { useDispatch, useSelect } from "@wordpress/data";
-import { useEffect, useState} from "@wordpress/element";
-import { Pagination } from "antd";
+import { useEffect } from "@wordpress/element";
 import ModuleList from "../modules/ModuleList";
 import { Ajax } from "../../ajax";
 import { __ } from "@wordpress/i18n";
 
 function ModulesSetup() {
-
-  const perPageItem = 6;
-
-  const [pagination, setPagination] = useState({
-    minValue: 0,
-    maxValue: perPageItem,
-    selectFilter: { modules: [] },
-    currentPage: 1,
-  });
-
   const { updateModules } = useDispatch("sgsb");
 
   // Get from WP data.
   const { allModules } = useSelect((select) => ({
     allModules: select("sgsb").getModules(),
   }));
-
-  const hanglePageItem = (pageNumber) => {
-    // Pagination calculation based on all Modules (preserves the current page)
-    const startIndex = (pageNumber - 1) * perPageItem;
-    const endIndex = startIndex + perPageItem;
-
-    setPagination({
-      ...pagination,
-      minValue: startIndex,
-      maxValue: endIndex,
-      currentPage: pageNumber,
-    });
-  };
-
-  useEffect(() => {
-    if (allModules) {
-      setPagination({
-        ...pagination,
-        selectFilter: { modules: allModules },
-      });
-    }
-  }, [allModules]);
 
   useEffect(() => {
     Ajax("get_all_modules").success((response) => {
@@ -62,24 +29,7 @@ function ModulesSetup() {
         </div>
         <ModuleList
           modules={allModules}
-          minValue={pagination?.minValue}
-          maxValue={pagination?.maxValue}
         />
-        <div
-          className="sgsb__module-pagination"
-          style={{
-            paddingLeft: "22px",
-          }}
-        >
-          <Pagination
-            defaultCurrent={1}
-            current={pagination?.currentPage}
-            defaultPageSize={perPageItem}
-            onChange={hanglePageItem}
-            total={allModules?.length}
-            hideOnSinglePage={false}
-          />
-        </div>
       </div>
     </div>
   );

--- a/assets/src/components/modules/ModuleList.jsx
+++ b/assets/src/components/modules/ModuleList.jsx
@@ -3,7 +3,7 @@ import { nanoid } from 'nanoid';
 import { Row } from "antd";
 import ModuleCard from './ModuleCard';
 
-const ModuleList = ({ modules, filterActiveModules = false, minValue = 0, maxValue = 6, searchModule = "" }) => {
+const ModuleList = ({ modules, filterActiveModules = false, searchModule = "" }) => {
   return (
     <>
       <Row className="sgsb-admin-dashboard-module-box-content">
@@ -12,7 +12,6 @@ const ModuleList = ({ modules, filterActiveModules = false, minValue = 0, maxVal
             module.name.toLowerCase().includes(searchModule.toLowerCase())
           )
           .filter((module) => (filterActiveModules ? module.status : true)) // Filter based on the filterActiveModules state
-          .slice(minValue, maxValue)
           .map((module) => (
             <ModuleCard module={module} key={nanoid()} />
           ))}

--- a/assets/src/components/modules/Modules.js
+++ b/assets/src/components/modules/Modules.js
@@ -1,6 +1,6 @@
 import { useDispatch, useSelect } from "@wordpress/data";
-import { useEffect, useState, useMemo } from "@wordpress/element";
-import { Button, Col, Image, Pagination, Row } from "antd";
+import { useEffect, useState } from "@wordpress/element";
+import { Button, Col, Image, Row } from "antd";
 import ModuleList from "./ModuleList";
 import { Ajax } from "../../ajax";
 import ModuleSearch from "./ModuleSearch";
@@ -14,22 +14,15 @@ import { __ } from "@wordpress/i18n";
 import ActivationAlert from "./ActivationAlert";
 
 function Modules() {
-  // pagination
   const proPluginActivated = sgsbAdmin.isPro;
-  const perPageItem = 6;
-  const [minValue, setMinValue] = useState(0);
-  const [maxValue, setMaxValue] = useState(perPageItem);
-
   const { updateModules, setPageLoading } = useDispatch("sgsb");
   const [searchModule, setSearchModule] = useState("");
   const [selectFilter, setSelectFilter] = useState({
     modules: [],
   });
   const [filterActiveModules, setFilterActiveModules] = useState(false);
-  const [currentPage, setCurrentPage] = useState(1);
   // handle active module of settings url
   const [activeModule, setActiveModule] = useState(false);
-  const [activeClass, setActiveClass] = useState(proPluginActivated);
   const [activeModalData, setActiveModalData] = useState("");
 
   // Get from WP data.
@@ -37,39 +30,11 @@ function Modules() {
     allModules: select("sgsb").getModules(),
   }));
 
-  //check the both active and deactivatd module length
-  const activeModuleLength = allModules.filter((module) =>
-    filterActiveModules ? module.status : true
-  ).length;
-
   // check only tha activated Modules
   const activatedModules = allModules.filter((module) => module.status).length;
 
   const handlefilterChange = (checked) => {
-    setCurrentPage(1);
-    setMinValue(0);
-    setMaxValue(perPageItem);
     setFilterActiveModules(checked);
-  };
-
-  const hanglePageItem = (pageNumber) => {
-    if (filterActiveModules) {
-      // Pagination calculation based on active Modules
-      const startIndex = (pageNumber - 1) * perPageItem;
-      const endIndex = startIndex + perPageItem;
-
-      setMinValue(startIndex);
-      setMaxValue(endIndex);
-      setCurrentPage(pageNumber);
-    } else {
-      // Pagination calculation based on all Modules (preserves the current page)
-      const startIndex = (pageNumber - 1) * perPageItem;
-      const endIndex = startIndex + perPageItem;
-
-      setMinValue(startIndex);
-      setMaxValue(endIndex);
-      setCurrentPage(pageNumber);
-    }
   };
 
   //Modal alert handler
@@ -92,17 +57,6 @@ function Modules() {
     });
   };
 
-  // handle active class
-  const toggleMenuClass = () => {
-    setActiveClass((prevIsActive) => !prevIsActive);
-  };
-
-  const totalItems = useMemo(() => {
-    return filterActiveModules
-      ? allModules.filter((module) => module.status).length
-      : allModules.length;
-  }, [filterActiveModules, allModules]);
-
   const handleLiClick = (routeName) => {
     const link = `admin.php?page=sgsb-settings#/${routeName}`;
     window.location.href = link;
@@ -123,22 +77,6 @@ function Modules() {
     });
   }, []);
 
-  useEffect(() => {
-    if (filterActiveModules) {
-      // If filterActiveModules is true, recalculate pagination based on active Modules
-      const newCurrentPage = Math.ceil(activeModuleLength / perPageItem);
-      const updatedCurrentPage =
-        currentPage > newCurrentPage ? currentPage - 1 : currentPage;
-      const newMaxValue = updatedCurrentPage * perPageItem;
-      const newMinValue = newMaxValue - perPageItem;
-
-      // Update pagination data
-      setMaxValue(newMaxValue);
-      setMinValue(newMinValue);
-      setCurrentPage(updatedCurrentPage);
-    }
-  }, [allModules, perPageItem]);
-
   /**
    *
    * Side Effect loading for if deactivated Modules page if the Modules are being deactivate and
@@ -148,9 +86,6 @@ function Modules() {
 
   useEffect(() => {
     if (activatedModules === 0 && filterActiveModules) {
-      setCurrentPage(1);
-      setMinValue(0);
-      setMaxValue(perPageItem);
       setFilterActiveModules(false);
     }
   }, [activatedModules]);
@@ -279,25 +214,7 @@ function Modules() {
           modules={selectFilter.modules}
           filterActiveModules={filterActiveModules}
           searchModule={searchModule}
-          minValue={minValue}
-          maxValue={maxValue}
         />
-        <div
-          className="sgsb__module-pagination"
-          style={{
-            paddingTop: "80px",
-            paddingLeft: "22px",
-          }}
-        >
-          <Pagination
-            defaultCurrent={1}
-            current={currentPage}
-            defaultPageSize={perPageItem}
-            onChange={hanglePageItem}
-            total={totalItems}
-            hideOnSinglePage={false}
-          />
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### Closes

* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/99


### How to test the changes in this Pull Request:
* Just follow as the issue description.

### Changelog entry
```text
- **update:** Remove pagination from module list and related components
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed client-side pagination from the Modules view; pagination controls are no longer displayed.
  * Module list now renders all modules that match the search and optional “Active” filter (no page slicing).
  * Streamlined filtering and UI behavior for simpler, more consistent browsing of modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->