### PR TITLE
Replace direct function calls with Helper class methods for form sanitization

### DIFF
--- a/modules/countdown-timer/includes/Ajax.php
+++ b/modules/countdown-timer/includes/Ajax.php
@@ -7,6 +7,7 @@
 
 namespace STOREGROWTH\SPSB\Modules\CountdownTimer;
 
+use STOREGROWTH\SPSB\Helper;
 use STOREGROWTH\SPSB\Interfaces\HookRegistry;
 
 // If this file is called directly, abort.
@@ -41,8 +42,8 @@ class Ajax implements HookRegistry {
 			wp_send_json_error();
 		}
 
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via `sgsb_sanitize_form_fields`.
-		$form_data = array_map( 'sgsb_sanitize_form_fields', wp_unslash( $_POST['form_data'] ) );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via ` Helper::class, 'sanitize_form_fields'`.
+		$form_data = array_map( array( Helper::class, 'sanitize_form_fields' ), wp_unslash( $_POST['form_data'] ) );
 
 		update_option( 'sgsb_countdown_timer_settings', $form_data );
 

--- a/modules/fly-cart/includes/Ajax.php
+++ b/modules/fly-cart/includes/Ajax.php
@@ -8,6 +8,7 @@
 namespace STOREGROWTH\SPSB\Modules\FlyCart;
 
 use STOREGROWTH\SPSB\Interfaces\HookRegistry;
+use STOREGROWTH\SPSB\Helper;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -44,10 +45,10 @@ class Ajax implements HookRegistry {
 			wp_send_json_error();
 		}
 
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via `sgsb_sanitize_form_fields`.
-		$form_data = array_map( 'sgsb_sanitize_form_fields', wp_unslash( $_POST['form_data'] ) );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via ` Helper::class, 'sanitize_form_fields'`.
+		$form_data = array_map( array( Helper::class, 'sanitize_form_fields' ), wp_unslash( $_POST['form_data'] ) );
 
-		$get_form_data = \STOREGROWTH\SPSB\Helper::get_settings( 'sgsb_fly_cart_settings', array() );
+		$get_form_data = Helper::get_settings( 'sgsb_fly_cart_settings', array() );
 		$merged_data   = array_merge( $get_form_data, $form_data );
 
 		update_option( 'sgsb_fly_cart_settings', $merged_data );
@@ -61,7 +62,7 @@ class Ajax implements HookRegistry {
 	public function get_settings() {
 		check_ajax_referer( 'sgsb_ajax_nonce' );
 
-		$form_data = \STOREGROWTH\SPSB\Helper::get_settings( 'sgsb_fly_cart_settings', array() );
+		$form_data = Helper::get_settings( 'sgsb_fly_cart_settings', array() );
 
 		wp_send_json_success( $form_data );
 	}

--- a/modules/quick-view/includes/Ajax.php
+++ b/modules/quick-view/includes/Ajax.php
@@ -8,6 +8,7 @@
 namespace STOREGROWTH\SPSB\Modules\QuickView;
 
 use STOREGROWTH\SPSB\Interfaces\HookRegistry;
+use STOREGROWTH\SPSB\Helper;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -43,8 +44,8 @@ class Ajax implements HookRegistry {
 			wp_send_json_error();
 		}
 
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via `sgsb_sanitize_form_fields`.
-		$form_data = array_map( 'sgsb_sanitize_form_fields', wp_unslash( $_POST['form_data'] ) );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via ` Helper::class, 'sanitize_form_fields'`.
+		$form_data = array_map( array( Helper::class, 'sanitize_form_fields' ), wp_unslash( $_POST['form_data'] ) );
 
 		update_option( 'sgsb_quick_view_settings', $form_data );
 

--- a/modules/stock-bar/includes/Ajax.php
+++ b/modules/stock-bar/includes/Ajax.php
@@ -7,6 +7,7 @@
 
 namespace STOREGROWTH\SPSB\Modules\StockBar;
 
+use STOREGROWTH\SPSB\Helper;
 use STOREGROWTH\SPSB\Interfaces\HookRegistry;
 
 // If this file is called directly, abort.
@@ -41,8 +42,8 @@ class Ajax implements HookRegistry {
 			wp_send_json_error();
 		}
 
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via `sgsb_sanitize_form_fields`.
-		$form_data = array_map( 'sgsb_sanitize_form_fields', wp_unslash( $_POST['form_data'] ) );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via ` Helper::class, 'sanitize_form_fields'`.
+		$form_data = array_map( array( Helper::class, 'sanitize_form_fields' ), wp_unslash( $_POST['form_data'] ) );
 
 		update_option( 'sgsb_stock_bar_settings', $form_data );
 


### PR DESCRIPTION
* closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/107
* closes https://github.com/getdokan/plugin-internal-tasks/issues/866