### PR TITLE
fix: handle undefined index for popup products in EnqueueScript

### DIFF
--- a/modules/sales-pop/includes/EnqueueScript.php
+++ b/modules/sales-pop/includes/EnqueueScript.php
@@ -52,7 +52,7 @@ class EnqueueScript implements HookRegistry {
 
 		if ( false !== $popup_properties ) {
 			$popup_properties  = maybe_unserialize( $popup_properties );
-			$popup_products    = $popup_properties['popup_products'];
+      $popup_products    = $popup_properties['popup_products'] ?? array();
 			$product_list      = array();
 			$product_url       = array();
 			$product_image_url = array();


### PR DESCRIPTION
* closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/128