### PR TITLE
🎯 fix: Direct checkout buy now button pro feature was listed in free version

### DIFF
--- a/modules/direct-checkout/includes/CommonHooks.php
+++ b/modules/direct-checkout/includes/CommonHooks.php
@@ -72,8 +72,7 @@ class CommonHooks implements HookRegistry {
 	 * @return string
 	 */
 	public function show_signle_direct_checkout_button_shop( $add_to_cart ) {
-
-		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) ) {
+		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) && SGSB_PRO_ACTIVE ) {
 			ob_start();
 			global $product;
 			$product_id                    = get_the_ID();
@@ -108,7 +107,7 @@ class CommonHooks implements HookRegistry {
 	 * @return string
 	 */
 	public function show_direct_checkout_button_shop( $add_to_cart ) {
-		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) ) {
+		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) && SGSB_PRO_ACTIVE ) {
 			ob_start();
 			$this->display_buy_now_button();
 			$buy_now_button = ob_get_contents();


### PR DESCRIPTION
* Fixes: https://github.com/getdokan/storegrowth-sales-booster-pro/issues/121