### PR TITLE
🎯 fix: General settings data was not saving on sales notification module

### DIFF
--- a/modules/sales-pop/includes/Ajax.php
+++ b/modules/sales-pop/includes/Ajax.php
@@ -38,7 +38,7 @@ class Ajax implements HookRegistry {
 	 * Order bump creation
 	 */
 	public function popup_products() {
-		wp_send_json_success( maybe_unserialize( \STOREGROWTH\SPSB\Helper::get_settings( 'sgsb_popup_products' ) ) );
+		wp_send_json_success( maybe_unserialize( get_option( 'sgsb_popup_products' ) ) );
 	}
 
 	/**
@@ -50,7 +50,7 @@ class Ajax implements HookRegistry {
 		$popup_products = isset( $popup_data['popup_data'] ) ? $popup_data['popup_data'] : array();
 		$popup_products = $this->form_validation( $popup_products );
 		update_option( 'sgsb_popup_products', maybe_serialize( $popup_products ) );
-		wp_send_json_success( maybe_unserialize( \STOREGROWTH\SPSB\Helper::get_settings( 'sgsb_popup_products' ) ) );
+		wp_send_json_success( maybe_unserialize( get_option( 'sgsb_popup_products' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
* Fixes: https://github.com/getdokan/storegrowth-sales-booster-pro/issues/124