### PR TITLE
Release/v2.0

### DIFF
--- a/modules/bogo/assets/src/components/OfferProductContent.jsx
+++ b/modules/bogo/assets/src/components/OfferProductContent.jsx
@@ -10,7 +10,7 @@ const OfferProductContent = ({ offerProduct, bogoItem }) => {
       (simpleProduct) =>
         simpleProduct?.value === parseInt(offerId)
     );
-  let discountedPrice = parseFloat(bogoItem?.discount_amount)?.toFixed(2);
+  let discountedPrice = parseFloat( bogoItem?.discount_amount ? bogoItem?.discount_amount : '0' )?.toFixed( 2 );
 
   if (bogoItem?.offer_type === "discount") {
     const currencySymbol = product?.currency;

--- a/modules/direct-checkout/includes/CommonHooks.php
+++ b/modules/direct-checkout/includes/CommonHooks.php
@@ -72,8 +72,7 @@ class CommonHooks implements HookRegistry {
 	 * @return string
 	 */
 	public function show_signle_direct_checkout_button_shop( $add_to_cart ) {
-
-		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) ) {
+		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) && SGSB_PRO_ACTIVE ) {
 			ob_start();
 			global $product;
 			$product_id                    = get_the_ID();
@@ -108,7 +107,7 @@ class CommonHooks implements HookRegistry {
 	 * @return string
 	 */
 	public function show_direct_checkout_button_shop( $add_to_cart ) {
-		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) ) {
+		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) && SGSB_PRO_ACTIVE ) {
 			ob_start();
 			$this->display_buy_now_button();
 			$buy_now_button = ob_get_contents();

--- a/modules/upsell-order-bump/assets/src/components/Preview.js
+++ b/modules/upsell-order-bump/assets/src/components/Preview.js
@@ -13,7 +13,7 @@ const Preview = ( { storeData } ) => {
         }
     const product = products_and_categories?.product_list?.simpleProductForOffer
         ?.find( simpleProduct => simpleProduct?.value === parseInt( storeData.offer_product ) );
-    let discountedPrice = parseFloat( storeData?.offer_amount )?.toFixed( 2 );
+    let discountedPrice = parseFloat( storeData?.offer_amount ? storeData?.offer_amount : '0' )?.toFixed( 2 );
 
     if ( storeData?.offer_type === 'discount' ) {
         const currencySymbol = product?.currency;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevented “NaN” prices by defaulting missing discount/offer amounts to 0.00 in BOGO and Order Bump previews, ensuring consistent price formatting.
  - Ensured the Buy Now button appears on shop pages only when eligible and PRO is active, avoiding unintended display.
- Chores
  - Improved reliability of price handling in promotional offer components without changing visible behavior beyond correcting invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->