### PR TITLE
fix: streamline data handling in SalesPop module by removing unnecessary serialization

### DIFF
--- a/modules/sales-pop/includes/Ajax.php
+++ b/modules/sales-pop/includes/Ajax.php
@@ -38,7 +38,7 @@ class Ajax implements HookRegistry {
 	 * Order bump creation
 	 */
 	public function popup_products() {
-		wp_send_json_success( maybe_unserialize( get_option( 'sgsb_popup_products' ) ) );
+		wp_send_json_success( get_option( 'sgsb_popup_products' ) );
 	}
 
 	/**
@@ -49,8 +49,8 @@ class Ajax implements HookRegistry {
 		$popup_data     = isset( $_POST['data'] ) ? json_decode( wp_unslash( $_POST['data'] ), true ) : array(); //phpcs:ignore
 		$popup_products = isset( $popup_data['popup_data'] ) ? $popup_data['popup_data'] : array();
 		$popup_products = $this->form_validation( $popup_products );
-		update_option( 'sgsb_popup_products', maybe_serialize( $popup_products ) );
-		wp_send_json_success( maybe_unserialize( get_option( 'sgsb_popup_products' ) ) );
+		update_option( 'sgsb_popup_products', $popup_products );
+		wp_send_json_success( get_option( 'sgsb_popup_products' ) );
 	}
 
 	/**

--- a/modules/sales-pop/includes/EnqueueScript.php
+++ b/modules/sales-pop/includes/EnqueueScript.php
@@ -122,7 +122,7 @@ class EnqueueScript implements HookRegistry {
 	 * @param string $screen name of screen.
 	 */
 	public function admin_enqueue_scripts( $screen ) {
-		$popup_properties = maybe_unserialize( \STOREGROWTH\SPSB\Helper::get_settings( 'sgsb_popup_products', true ) );
+		$popup_properties = \STOREGROWTH\SPSB\Helper::get_settings( 'sgsb_popup_products', true );
 
 		if ( 'storegrowth_page_sgsb-settings' === $screen ) {
 			add_action( 'admin_head', array( $this, 'admin_css' ) );

--- a/modules/sales-pop/includes/Providers/BootstrapServiceProvider.php
+++ b/modules/sales-pop/includes/Providers/BootstrapServiceProvider.php
@@ -5,6 +5,7 @@ namespace STOREGROWTH\SPSB\Modules\SalesPop\Providers;
 use STOREGROWTH\SPSB\DependencyManagement\BootableServiceProvider;
 use STOREGROWTH\SPSB\Modules\SalesPop\Ajax;
 use STOREGROWTH\SPSB\Modules\SalesPop\EnqueueScript;
+use STOREGROWTH\SPSB\Modules\SalesPop\SalesPOP;
 
 /**
  * BootstrapServiceProvider for the module.
@@ -27,6 +28,7 @@ class BootstrapServiceProvider extends BootableServiceProvider {
     protected $services = [
         EnqueueScript::class,
         Ajax::class,
+        SalesPOP::class
     ];
 
     /**

--- a/modules/sales-pop/includes/SalesPOP.php
+++ b/modules/sales-pop/includes/SalesPOP.php
@@ -41,7 +41,7 @@ class SalesPOP implements HookRegistry {
 	 * Popup for frontend
 	 */
 	public function footer_files() {
-		$popup_properties = maybe_unserialize( \STOREGROWTH\SPSB\Helper::get_settings( 'sgsb_popup_products', true ) );
+		$popup_properties = \STOREGROWTH\SPSB\Helper::get_settings( 'sgsb_popup_products', true );
 
 		if ( ! empty( $popup_properties['enable'] ) && ! empty( $popup_properties['popup_products'] ) ) {
 			include __DIR__ . '/../templates/popup-style.php';


### PR DESCRIPTION
* closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed cases where Sales Pop settings failed to load or showed outdated/incorrect product data.
  - Improved reliability of popup display by aligning with WordPress options handling.
  - Reduced potential admin-side errors when configuring popup products.

- Refactor
  - Simplified storage and retrieval of Sales Pop settings for consistency and stability.
  - Streamlined asset loading paths related to admin and frontend popups.
  - Enhanced service initialization to ensure Sales Pop components load predictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->