### PR TITLE
fix: add OrderBump service to BootstrapServiceProvider

### DIFF
--- a/modules/upsell-order-bump/includes/Providers/BootstrapServiceProvider.php
+++ b/modules/upsell-order-bump/includes/Providers/BootstrapServiceProvider.php
@@ -5,6 +5,7 @@ namespace STOREGROWTH\SPSB\Modules\UpsellOrderBump\Providers;
 use STOREGROWTH\SPSB\DependencyManagement\BootableServiceProvider;
 use STOREGROWTH\SPSB\Modules\UpsellOrderBump\Ajax;
 use STOREGROWTH\SPSB\Modules\UpsellOrderBump\EnqueueScript;
+use STOREGROWTH\SPSB\Modules\UpsellOrderBump\OrderBump;
 
 /**
  * BootstrapServiceProvider for the module.
@@ -27,6 +28,7 @@ class BootstrapServiceProvider extends BootableServiceProvider {
     protected $services = [
         EnqueueScript::class,
         Ajax::class,
+        OrderBump::class,
     ];
 
     /**


### PR DESCRIPTION
* closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Order Bump within the Upsell module, allowing targeted add-on offers during checkout to boost average order value.
  * Order Bump is now initialized by default for smoother setup; no manual activation required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->