### PR TITLE
🎯 fix: Discount amount option was not working for progressive discount

### DIFF
--- a/modules/progressive-discount-banner/includes/WoocommerceDiscount.php
+++ b/modules/progressive-discount-banner/includes/WoocommerceDiscount.php
@@ -7,6 +7,7 @@
 
 namespace STOREGROWTH\SPSB\Modules\ProgressiveDiscountBanner;
 
+use STOREGROWTH\SPSB\Interfaces\HookRegistry;
 use STOREGROWTH\SPSB\Traits\Singleton;
 
 // If this file is called directly, abort.
@@ -17,14 +18,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Add or Remove discount when product add/remove to cart.
  */
-class WoocommerceDiscount {
+class WoocommerceDiscount implements HookRegistry {
 
 	use Singleton;
 
 	/**
-	 * Constructor of Woocommerce_Discount class.
+	 * Register Hooks.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return void
 	 */
-	public function __construct() {
+	public function register_hooks(): void {
 		add_action( 'woocommerce_add_to_cart', array( $this, 'woocommerce_added_to_cart' ), 22 );
 		add_action( 'woocommerce_cart_item_restored', array( $this, 'woocommerce_added_to_cart' ), 22 );
 


### PR DESCRIPTION
* Fixes: https://github.com/getdokan/storegrowth-sales-booster-pro/issues/148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined initialization of the progressive discount logic to improve stability and maintainability.
  * Ensures discount calculations reliably trigger during add-to-cart, cart restore, and fee calculation flows.
  * No visible behavior changes expected for shoppers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->