### PR TITLE
fix: use sale price for countdown discount calculation if available

### DIFF
--- a/modules/countdown-timer/includes/CommonHooks.php
+++ b/modules/countdown-timer/includes/CommonHooks.php
@@ -118,8 +118,7 @@ class CommonHooks implements HookRegistry {
 	public function woocommerce_product_get_price( $price, $product ) {
 		// Check countdown discount is set.
 		if ( Helper::is_product_discountable( $product->get_id() ) ) {
-			// Use sale price if available, otherwise fallback to regular price
-			$base_price = $product->get_sale_price() ? floatval( $product->get_sale_price() ) : floatval( $product->get_regular_price() );
+			$base_price = floatval( $product->get_price() );
 			$discount_amount = get_post_meta( $product->get_id(), '_sgsb_countdown_timer_discount_amount', true );
 			$discount_amount = 100 - intval( $discount_amount );
 

--- a/modules/countdown-timer/includes/CommonHooks.php
+++ b/modules/countdown-timer/includes/CommonHooks.php
@@ -118,11 +118,12 @@ class CommonHooks implements HookRegistry {
 	public function woocommerce_product_get_price( $price, $product ) {
 		// Check countdown discount is set.
 		if ( Helper::is_product_discountable( $product->get_id() ) ) {
-			$float_price     = floatval( $product->get_regular_price() );
+			// Use sale price if available, otherwise fallback to regular price
+			$base_price = $product->get_sale_price() ? floatval( $product->get_sale_price() ) : floatval( $product->get_regular_price() );
 			$discount_amount = get_post_meta( $product->get_id(), '_sgsb_countdown_timer_discount_amount', true );
 			$discount_amount = 100 - intval( $discount_amount );
 
-			return ( $float_price * $discount_amount ) / 100;
+			return ( $base_price * $discount_amount ) / 100;
 		}
 
 		return $price;

--- a/modules/countdown-timer/includes/CommonHooks.php
+++ b/modules/countdown-timer/includes/CommonHooks.php
@@ -118,11 +118,11 @@ class CommonHooks implements HookRegistry {
 	public function woocommerce_product_get_price( $price, $product ) {
 		// Check countdown discount is set.
 		if ( Helper::is_product_discountable( $product->get_id() ) ) {
-			$base_price = floatval( $product->get_price() );
+			$current_price = floatval( $product->get_price() );
 			$discount_amount = get_post_meta( $product->get_id(), '_sgsb_countdown_timer_discount_amount', true );
 			$discount_amount = 100 - intval( $discount_amount );
 
-			return ( $base_price * $discount_amount ) / 100;
+			return ( $current_price * $discount_amount ) / 100;
 		}
 
 		return $price;


### PR DESCRIPTION
Currently, in the countdown timer module, the discount amount is always calculated from the regular price. I have to change this logic so that the discount is calculated from the sale price (if a sale price is available); otherwise, it should fall back to the regular price. Update the module to ensure the final offer price reflects this rule.

I have also tested the WooCommerce coupon feature, which also calculates the discount ammount on this way..




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Countdown timer discounts now calculate from a product’s current price (uses sale price when available, otherwise regular price).
  * Ensures consistent, accurate discounting across product pages, cart, and checkout.
  * Prevents double- or over-discounting when a sale price is already applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->