### PR TITLE
Fix BOGO alternate products feature

### DIFF
--- a/modules/bogo/assets/css/order-bogo-front.css
+++ b/modules/bogo/assets/css/order-bogo-front.css
@@ -238,8 +238,8 @@ a.custom-choose-product {
 }
 
 .woocommerce-cart .cart_item a.custom-choose-product,
-.woocommerce-checkout .checkout-review-order-table .product-name {
-    display: inline;
+.woocommerce-checkout .checkout-review-order-table .product-name a.custom-choose-product {
+    display: inline !important;
 }
 
 #overlay {

--- a/modules/bogo/includes/Ajax.php
+++ b/modules/bogo/includes/Ajax.php
@@ -60,16 +60,19 @@ class Ajax implements HookRegistry {
 	}
 
 	public function handle_update_offer_product() {
-		check_ajax_referer( 'ajd_protected' );
+		// Verify nonce for security
+		if ( ! isset( $_POST['_ajax_nonce'] ) || ! wp_verify_nonce( $_POST['_ajax_nonce'], 'ajd_protected' ) ) {
+			wp_send_json_error( 'Security check failed.' );
+		}
 
 		$data = ! empty( $_POST['data'] ) ? wc_clean( $_POST['data'] ) : array();
 		if ( empty( $data ) ) {
 			wp_send_json_error( 'Choose able product data can\'t be empty.' );
 		}
 
-		$item_key            = isset( $data['cart_item_key'] ) ? intval( $data['cart_item_key'] ) : 0;
+		$item_key            = isset( $data['cart_item_key'] ) ? sanitize_text_field( $data['cart_item_key'] ) : '';
 		$main_product_id     = isset( $data['main_product_id'] ) ? intval( $data['main_product_id'] ) : 0;
-		$product_link_key    = isset( $data['product_link_key'] ) ? esc_html( $data['product_link_key'] ) : '';
+		$product_link_key    = isset( $data['product_link_key'] ) ? sanitize_text_field( $data['product_link_key'] ) : '';
 		$offer_product_cost  = isset( $data['offer_product_cost'] ) ? floatval( $data['offer_product_cost'] ) : 0;
 		$selected_product_id = isset( $data['selected_product_id'] ) ? intval( $data['selected_product_id'] ) : 0;
 
@@ -80,7 +83,8 @@ class Ajax implements HookRegistry {
 		// Logic to remove the existing offer product and add the new one.
 		$offer_product_quantity = 1;
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-			if ( isset( $cart_item['bogo_offer'] ) && $cart_item['bogo_product_for'] == $main_product_id ) {
+			if ( isset( $cart_item['bogo_offer'] ) && $cart_item['bogo_offer'] && 
+			     isset( $cart_item['bogo_product_for'] ) && $cart_item['bogo_product_for'] == $main_product_id ) {
 				$offer_product_quantity = $cart_item['quantity'];
 				WC()->cart->remove_cart_item( $cart_item_key );
 				break;
@@ -95,7 +99,7 @@ class Ajax implements HookRegistry {
 			'',
 			array(
 				'bogo_offer'            => true,
-                'parent_key'            => $item_key,
+                'parent_key'            => $product_link_key, // Use the product link key as parent
                 'bogo_product_for'      => $main_product_id,
 				'bogo_offer_price'      => $offer_product_cost,
                 'changed_product_id'    => $selected_product_id,
@@ -103,8 +107,9 @@ class Ajax implements HookRegistry {
 			)
 		);
 
-        if ( $free_product_key && isset( WC()->cart->cart_contents[ $item_key ] ) ) {
-            WC()->cart->cart_contents[ $item_key ]['child_key'] = $free_product_key;
+        // Update the parent cart item with the new child key
+        if ( $free_product_key && ! empty( $product_link_key ) && isset( WC()->cart->cart_contents[ $product_link_key ] ) ) {
+            WC()->cart->cart_contents[ $product_link_key ]['child_key'] = $free_product_key;
         }
 
 		wp_send_json_success( 'Product updated successfully.' );

--- a/modules/bogo/templates/bogo-offer-products-popup.php
+++ b/modules/bogo/templates/bogo-offer-products-popup.php
@@ -18,6 +18,9 @@ if ( ! empty( $cart_item['changed_product_id'] ) ) {
 
 $offer_products = Helper::get_alternate_offer_products( $cart_item['bogo_product_for'], $item_id );
 
+// Get bogo settings for discount calculation
+$bogo_settings = $bogo_settings ?? Helper::prepare_bogo_settings( $cart_item['bogo_product_for'], $cart_item['product_id'], $cart_item['variation_id'] ?? 0 );
+
 if ( ! empty( $offer_products ) ) : ?>
 	<p>
         <a href="#" class="custom-choose-product">
@@ -35,27 +38,37 @@ if ( ! empty( $offer_products ) ) : ?>
 			<div id="product-list">
 				<ul style="margin: 0;">
 					<?php
-					foreach ( $offer_products as $product_id ) :
-						$product            = wc_get_product( $product_id );
+					foreach ( $offer_products as $product_obj ) :
+						// Handle both product objects and product IDs
+						$product = is_object( $product_obj ) ? $product_obj : wc_get_product( $product_obj );
+						if ( ! $product ) {
+							continue;
+						}
+						
 						$image_id           = $product->get_image_id();
 						$image_url          = wp_get_attachment_image_src( $image_id, 'full' );
 						$offer_product_cost = 0;
 						if ( ! empty( $bogo_settings['offer_type'] ) && $bogo_settings['offer_type'] === 'discount' ) {
-							$offer_product_cost = max( $product->get_price() - ( $product->get_price() * ( $bogo_settings['discount_amount'] / 100 ) ), 0 );
+							$discount_amount = ! empty( $bogo_settings['discount_amount'] ) ? floatval( $bogo_settings['discount_amount'] ) : 0;
+							$offer_product_cost = max( $product->get_price() - ( $product->get_price() * ( $discount_amount / 100 ) ), 0 );
 						}
 						?>
 						<li>
 							<div class="alternate-product-container">
-							<img src="<?php echo esc_url( $image_url[0] ); ?>" alt="product">
-							<div class="altenate-product-heading"><h3><?php echo $product->get_title(); ?></h3>
-							<span class="choosen-offer-product"
-								data-product-id="<?php echo esc_attr( $product->get_id() ); ?>"
-                                data-item-key="<?php echo esc_attr( $cart_item['parent_key'] ); ?>"
-                                data-offer-product-cost="<?php echo esc_attr( $offer_product_cost ); ?>"
-								data-main-product-id="<?php echo esc_attr( $cart_item['bogo_product_for'] ); ?>"
-								data-product-link-key="<?php echo esc_attr( $cart_item['linked_to_product_key'] ); ?>">
-								<?php esc_html_e( 'Choose', 'storegrowth-sales-booster' ); ?>
-							</span></div>
+							<?php if ( ! empty( $image_url ) && ! empty( $image_url[0] ) ) : ?>
+								<img src="<?php echo esc_url( $image_url[0] ); ?>" alt="<?php echo esc_attr( $product->get_name() ); ?>">
+							<?php endif; ?>
+							<div class="altenate-product-heading">
+								<h3><?php echo esc_html( $product->get_name() ); ?></h3>
+								<span class="choosen-offer-product"
+									data-product-id="<?php echo esc_attr( $product->get_id() ); ?>"
+	                                data-item-key="<?php echo esc_attr( $cart_item['parent_key'] ?? '' ); ?>"
+	                                data-offer-product-cost="<?php echo esc_attr( $offer_product_cost ); ?>"
+									data-main-product-id="<?php echo esc_attr( $cart_item['bogo_product_for'] ); ?>"
+									data-product-link-key="<?php echo esc_attr( $cart_item['linked_to_product_key'] ?? '' ); ?>">
+									<?php esc_html_e( 'Choose', 'storegrowth-sales-booster' ); ?>
+								</span>
+							</div>
 							</div>
 						</li>
 					<?php endforeach; ?>


### PR DESCRIPTION
- Fix missing bogo_settings variable in popup template
- Improve product object handling in template loop
- Add proper image URL error handling
- Fix Ajax security and data validation
- Correct cart item relationship logic
- Fix CSS display issue for choose product link
- Add safe array access for data attributes

This resolves issues where the alternate products modal wasn't displaying or functioning correctly in the cart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hardened AJAX validation with stronger nonce checks and clearer error responses.

* **Bug Fixes**
  * More reliable linking of BOGO items in the cart, reducing mismatches.
  * Accurate discount calculations and safer handling of missing/invalid products.
  * BOGO popup now supports both product IDs and product objects.
  * Safer rendering to avoid broken images or notices; improved output escaping.

* **Style**
  * “Choose product” link now displays inline with the product name in checkout/cart for better alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->