### PR TITLE
Fix/bogo admin design settings not saving to database

### DIFF
--- a/modules/bogo/includes/BogoDataManager.php
+++ b/modules/bogo/includes/BogoDataManager.php
@@ -244,6 +244,16 @@ class BogoDataManager {
 			'offer_end'               => self::normalize_date_field( $data['offer_end'] ?? null ),
 			'offer_schedule'          => wp_json_encode( $data['offer_schedule'] ?? array( 'daily' ) ),
 			'status'                  => apply_filters( 'sgsb_bogo_status',  $data['status'] ?? 'active', $type, $product_id, $variation_id ),
+			// Design fields
+			'box_border_style'        => $data['box_border_style'] ?? 'solid',
+			'box_border_color'        => $data['box_border_color'] ?? '#e0e0e0',
+			'box_top_margin'          => $data['box_top_margin'] ?? 10,
+			'box_bottom_margin'       => $data['box_bottom_margin'] ?? 10,
+			'discount_background_color' => $data['discount_background_color'] ?? '#ff6b6b',
+			'discount_text_color'     => $data['discount_text_color'] ?? '#ffffff',
+			'discount_font_size'      => $data['discount_font_size'] ?? 14,
+			'product_description_text_color' => $data['product_description_text_color'] ?? '#333333',
+			'product_description_font_size' => $data['product_description_font_size'] ?? 12,
 		);
 
 		// Add type-specific fields
@@ -538,6 +548,15 @@ class BogoDataManager {
 			offer_end DATE DEFAULT NULL,
 			offer_schedule JSON DEFAULT NULL,
 			status ENUM('active', 'inactive') DEFAULT 'active',
+			box_border_style VARCHAR(20) DEFAULT 'solid',
+			box_border_color VARCHAR(20) DEFAULT '#e0e0e0',
+			box_top_margin INT DEFAULT 10,
+			box_bottom_margin INT DEFAULT 10,
+			discount_background_color VARCHAR(20) DEFAULT '#ff6b6b',
+			discount_text_color VARCHAR(20) DEFAULT '#ffffff',
+			discount_font_size INT DEFAULT 14,
+			product_description_text_color VARCHAR(20) DEFAULT '#333333',
+			product_description_font_size INT DEFAULT 12,
 			created_by BIGINT DEFAULT NULL,
 			updated_by BIGINT DEFAULT NULL,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/modules/bogo/includes/BogoDataManager.php
+++ b/modules/bogo/includes/BogoDataManager.php
@@ -244,16 +244,18 @@ class BogoDataManager {
 			'offer_end'               => self::normalize_date_field( $data['offer_end'] ?? null ),
 			'offer_schedule'          => wp_json_encode( $data['offer_schedule'] ?? array( 'daily' ) ),
 			'status'                  => apply_filters( 'sgsb_bogo_status',  $data['status'] ?? 'active', $type, $product_id, $variation_id ),
-			// Design fields
-			'box_border_style'        => $data['box_border_style'] ?? 'solid',
-			'box_border_color'        => $data['box_border_color'] ?? '#e0e0e0',
-			'box_top_margin'          => $data['box_top_margin'] ?? 10,
-			'box_bottom_margin'       => $data['box_bottom_margin'] ?? 10,
-			'discount_background_color' => $data['discount_background_color'] ?? '#ff6b6b',
-			'discount_text_color'     => $data['discount_text_color'] ?? '#ffffff',
-			'discount_font_size'      => $data['discount_font_size'] ?? 14,
-			'product_description_text_color' => $data['product_description_text_color'] ?? '#333333',
-			'product_description_font_size' => $data['product_description_font_size'] ?? 12,
+			// Design settings as JSON
+			'design_settings'         => wp_json_encode( array(
+				'box_border_style'        => $data['box_border_style'] ?? 'solid',
+				'box_border_color'        => $data['box_border_color'] ?? '#e0e0e0',
+				'box_top_margin'          => $data['box_top_margin'] ?? 10,
+				'box_bottom_margin'       => $data['box_bottom_margin'] ?? 10,
+				'discount_background_color' => $data['discount_background_color'] ?? '#ff6b6b',
+				'discount_text_color'     => $data['discount_text_color'] ?? '#ffffff',
+				'discount_font_size'      => $data['discount_font_size'] ?? 14,
+				'product_description_text_color' => $data['product_description_text_color'] ?? '#333333',
+				'product_description_font_size' => $data['product_description_font_size'] ?? 12,
+			) ),
 		);
 
 		// Add type-specific fields
@@ -349,6 +351,10 @@ class BogoDataManager {
 				'product_page_message' => $offer['product_page_message'],
 				'offered_categories' => $offer['offered_categories'] ?? array(),
 			);
+			
+			// Extract design settings from JSON
+			$design_settings = self::get_design_settings( $offer['design_settings'] ?? null );
+			$formatted_offer = array_merge( $formatted_offer, $design_settings );
 			
 			// Add backward compatibility fields
 			$formatted_offer['name_of_order_bogo'] = $offer['name'] ?? '';
@@ -548,15 +554,7 @@ class BogoDataManager {
 			offer_end DATE DEFAULT NULL,
 			offer_schedule JSON DEFAULT NULL,
 			status ENUM('active', 'inactive') DEFAULT 'active',
-			box_border_style VARCHAR(20) DEFAULT 'solid',
-			box_border_color VARCHAR(20) DEFAULT '#e0e0e0',
-			box_top_margin INT DEFAULT 10,
-			box_bottom_margin INT DEFAULT 10,
-			discount_background_color VARCHAR(20) DEFAULT '#ff6b6b',
-			discount_text_color VARCHAR(20) DEFAULT '#ffffff',
-			discount_font_size INT DEFAULT 14,
-			product_description_text_color VARCHAR(20) DEFAULT '#333333',
-			product_description_font_size INT DEFAULT 12,
+			design_settings JSON DEFAULT NULL,
 			created_by BIGINT DEFAULT NULL,
 			updated_by BIGINT DEFAULT NULL,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -618,6 +616,34 @@ class BogoDataManager {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Extract design settings from JSON with defaults.
+	 *
+	 * @param string|array $design_settings_json JSON string or decoded array.
+	 * @return array Design settings with defaults.
+	 */
+	public static function get_design_settings( $design_settings_json ) {
+		$design_settings = array();
+		
+		if ( is_string( $design_settings_json ) ) {
+			$design_settings = json_decode( $design_settings_json, true ) ?: array();
+		} elseif ( is_array( $design_settings_json ) ) {
+			$design_settings = $design_settings_json;
+		}
+		
+		return array_merge( array(
+			'box_border_style'        => 'solid',
+			'box_border_color'        => '#e0e0e0',
+			'box_top_margin'          => 10,
+			'box_bottom_margin'       => 10,
+			'discount_background_color' => '#ff6b6b',
+			'discount_text_color'     => '#ffffff',
+			'discount_font_size'      => 14,
+			'product_description_text_color' => '#333333',
+			'product_description_font_size' => 12,
+		), $design_settings );
 	}
 
 	/**

--- a/modules/bogo/includes/OrderBogo.php
+++ b/modules/bogo/includes/OrderBogo.php
@@ -100,7 +100,7 @@ class OrderBogo implements HookRegistry {
 			$product_category_ids = is_array( $product_categories ) ? $product_categories : array();
 
 			foreach ( $offers as $offer ) {
-				if ( $offer['status'] !== 'active' ) {
+				if ( ! isset( $offer['status'] ) || $offer['status'] !== 'active' ) {
 					continue;
 				}
 

--- a/modules/bogo/includes/REST/BogoController.php
+++ b/modules/bogo/includes/REST/BogoController.php
@@ -432,14 +432,8 @@ class BogoController extends WP_REST_Controller {
             );
         }
 
-        // Log raw data for debugging
-        error_log( 'Raw request data: ' . print_r( $data, true ) );
-
         // Normalize data
         $data = $this->normalize_request_data( $data );
-
-        // Log normalized data for debugging
-        error_log( 'Normalized data: ' . print_r( $data, true ) );
 
         // Validate required fields
         if ( ! isset( $data['name_of_order_bogo'] ) || trim( $data['name_of_order_bogo'] ) === '' ) {
@@ -456,6 +450,29 @@ class BogoController extends WP_REST_Controller {
                 __( 'Missing or empty required field: offer_type', 'storegrowth-sales-booster' ),
                 [ 'status' => 400 ]
             );
+        }
+
+        // Validate design fields are present
+        $design_fields = [
+            'box_border_style',
+            'box_border_color', 
+            'box_top_margin',
+            'box_bottom_margin',
+            'discount_background_color',
+            'discount_text_color',
+            'discount_font_size',
+            'product_description_text_color',
+            'product_description_font_size'
+        ];
+        
+        foreach ( $design_fields as $field ) {
+            if ( ! isset( $data[ $field ] ) || trim( $data[ $field ] ) === '' ) {
+                return new WP_Error(
+                    'missing_design_field',
+                    __( 'Missing or empty required design field: ' . $field, 'storegrowth-sales-booster' ),
+                    [ 'status' => 400 ]
+                );
+            }
         }
 
         return $data;
@@ -508,6 +525,25 @@ class BogoController extends WP_REST_Controller {
 		// Ensure offer_schedule has a default value
 		if ( ! isset( $data['offer_schedule'] ) || empty( $data['offer_schedule'] ) ) {
 			$data['offer_schedule'] = array( 'daily' );
+		}
+
+		// Normalize design fields
+		$design_fields = [
+			'box_border_style',
+			'box_border_color', 
+			'box_top_margin',
+			'box_bottom_margin',
+			'discount_background_color',
+			'discount_text_color',
+			'discount_font_size',
+			'product_description_text_color',
+			'product_description_font_size'
+		];
+		
+		foreach ( $design_fields as $field ) {
+			if ( isset( $data[ $field ] ) ) {
+				$data[ $field ] = sanitize_text_field( $data[ $field ] );
+			}
 		}
 
 		// Normalize date fields - convert empty strings or invalid dates to null

--- a/modules/bogo/includes/REST/BogoController.php
+++ b/modules/bogo/includes/REST/BogoController.php
@@ -314,8 +314,6 @@ class BogoController extends WP_REST_Controller {
             return new WP_REST_Response( [ 'error' => __( 'Failed to create BOGO offer.', 'storegrowth-sales-booster' ) ], 400 );
         }
 
-        error_log( 'New bogo ID ' .  $result );
-
         $created_data = BogoDataManager::get_bogo_offer( $result );
         if ( ! $created_data ) {
             return new WP_REST_Response( [ 'error' => __( 'Failed to retrieve created BOGO offer.', 'storegrowth-sales-booster' ) ], 500 );

--- a/modules/bogo/templates/bogo-product-front-view.php
+++ b/modules/bogo/templates/bogo-product-front-view.php
@@ -8,7 +8,17 @@
 // Check if essential variables are set before using them.
 use STOREGROWTH\SPSB\Modules\BoGo\Helper;
 
+// Helper function to get design values from JSON design_settings
+function get_design_value( $bogo_info, $property ) {
+    if ( isset( $bogo_info->design_settings ) && is_string( $bogo_info->design_settings ) ) {
+        $design_data = json_decode( $bogo_info->design_settings, true );
+        return $design_data[ $property ] ?? '';
+    }
+    return '';
+}
+
 if ( isset( $bogo_info, $offered_product, $offer_product_id, $image_url, $regular_price, $offer_price ) ) {
+
 	$bogo_message = ! empty( $bogo_info->product_page_message ) ? esc_html( $bogo_info->product_page_message ) :
         __( 'Buy 1, unit of any product from this product and get 1 unit free of the same product', 'storegrowth-sales-booster' );
 	$bogo_message = str_replace( '[offered_product]', get_the_title( $offered_product ), $bogo_message );
@@ -20,18 +30,23 @@ if ( isset( $bogo_info, $offered_product, $offer_product_id, $image_url, $regula
             class="offer-main-wrap"
             style="
                 <?php
-                    echo ( 'no_border' !== $bogo_info->box_border_style ?
-                    'border: 2px ' . esc_attr( $bogo_info->box_border_style ) . ' ' . esc_attr( $bogo_info->box_border_color ) . '; ' : '' ) .
-                    'margin-top: ' . esc_attr( $bogo_info->box_top_margin ) . 'px; margin-bottom: ' .  esc_attr( $bogo_info->box_bottom_margin ) . 'px;'
+                    $border_style = get_design_value( $bogo_info, 'box_border_style' );
+                    $border_color = get_design_value( $bogo_info, 'box_border_color' );
+                    $top_margin = get_design_value( $bogo_info, 'box_top_margin' );
+                    $bottom_margin = get_design_value( $bogo_info, 'box_bottom_margin' );
+                    
+                    echo ( 'no_border' !== $border_style ?
+                    'border: 2px ' . esc_attr( $border_style ) . ' ' . esc_attr( $border_color ) . '; ' : '' ) .
+                    'margin-top: ' . esc_attr( $top_margin ) . 'px; margin-bottom: ' . esc_attr( $bottom_margin ) . 'px;'
                 ?>
             "
         >
-			<div class="dynamic-offer-text" style="background: <?php echo esc_attr( $bogo_info->discount_background_color ); ?>;
-													color: <?php echo esc_attr( $bogo_info->discount_text_color ); ?>;
-													font-size: <?php echo esc_attr( $bogo_info->discount_font_size ); ?>px;">
+			<div class="dynamic-offer-text" style="background: <?php echo esc_attr( get_design_value( $bogo_info, 'discount_background_color' ) ); ?>;
+													color: <?php echo esc_attr( get_design_value( $bogo_info, 'discount_text_color' ) ); ?>;
+													font-size: <?php echo esc_attr( get_design_value( $bogo_info, 'discount_font_size' ) ); ?>px;">
 				<svg width='15' height='15' viewBox='0 0 12 12' fill='none' xmlns='http://www.w3.org/2000/svg'>
                     <path
-						fill='<?php echo esc_attr( $bogo_info->discount_text_color ); ?>'
+						fill='<?php echo esc_attr( get_design_value( $bogo_info, 'discount_text_color' ) ); ?>'
 						d='M6.35818 0.158203C6.08866 0.158203 5.81928 0.261688 5.61466 0.466306L5.2127 0.868251C4.84967 1.23128 4.35705 1.43443 3.84365 1.43443H3.2095C2.63076 1.43443 2.15787 1.90729 2.15787 2.48604V2.95182V3.12053C2.15787 3.63394 1.95471 4.12619 1.59169 4.48922L1.18974 4.89117C0.780504 5.3004 0.780504 5.96965 1.18974 6.37888L1.59169 6.78083C1.95471 7.14386 2.15787 7.63577 2.15787 8.14918V8.78366C2.15787 9.36241 2.63076 9.83528 3.2095 9.83528H3.84365C4.35705 9.83528 4.84967 10.0388 5.2127 10.4018L5.61466 10.8034C6.02389 11.2126 6.69247 11.2126 7.1017 10.8034L7.504 10.4018C7.86703 10.0388 8.35931 9.83528 8.87271 9.83528H9.50686C10.0856 9.83528 10.5585 9.36241 10.5585 8.78366V8.14918C10.5585 7.63577 10.7634 7.14386 11.1264 6.78083L11.528 6.37888C11.9372 5.96964 11.9372 5.30041 11.528 4.89117L11.1264 4.48922C10.7634 4.12618 10.5585 3.63394 10.5585 3.12053V2.48604C10.5585 1.90729 10.0856 1.43443 9.50686 1.43443H8.87271C8.35931 1.43443 7.86703 1.23128 7.504 0.868251L7.1017 0.466306C6.89709 0.261687 6.6277 0.158204 6.35818 0.158203ZM5.03537 3.41518C5.52954 3.41518 5.93415 3.82012 5.93415 4.31429C5.93415 4.80846 5.52954 5.21341 5.03537 5.21341C4.54119 5.21341 4.13623 4.80846 4.13623 4.31429C4.13623 3.82012 4.54119 3.41518 5.03537 3.41518ZM8.13402 3.65669C8.18088 3.65643 8.22593 3.6748 8.25926 3.70775C8.27581 3.72405 8.28899 3.74346 8.29803 3.76486C8.30708 3.78625 8.31182 3.80923 8.31198 3.83246C8.31214 3.85569 8.30772 3.87873 8.29897 3.90025C8.29022 3.92177 8.27732 3.94136 8.261 3.95789L4.67896 7.56092C4.64604 7.59399 4.60137 7.6127 4.5547 7.61296C4.50804 7.61322 4.46315 7.59502 4.42986 7.56232C4.41325 7.54601 4.40004 7.52659 4.39096 7.50516C4.38188 7.48373 4.37713 7.46071 4.37697 7.43744C4.37681 7.41417 4.38124 7.39109 4.39002 7.36954C4.3988 7.34798 4.41175 7.32837 4.42812 7.31184L8.01015 3.70916C8.04292 3.67603 8.08743 3.65717 8.13402 3.65669ZM5.03537 3.76882C4.73224 3.76882 4.48988 4.0112 4.48988 4.31429C4.48988 4.61739 4.73224 4.85977 5.03537 4.85977C5.33849 4.85977 5.58085 4.61739 5.58085 4.31429C5.58085 4.0112 5.33849 3.76882 5.03537 3.76882ZM7.68134 6.05629C8.17552 6.05629 8.58047 6.46124 8.58047 6.95541C8.58047 7.44958 8.17552 7.85314 7.68134 7.85314C7.18717 7.85314 6.78359 7.44958 6.78359 6.95541C6.78359 6.46124 7.18717 6.05629 7.68134 6.05629ZM7.68134 6.40993C7.37822 6.40993 7.1369 6.65231 7.1369 6.95541C7.1369 7.2585 7.37822 7.50088 7.68134 7.50088C7.98447 7.50088 8.22648 7.2585 8.22648 6.95541C8.22648 6.65231 7.98447 6.40993 7.68134 6.40993Z'
 					/>
 				</svg>
@@ -42,9 +57,9 @@ if ( isset( $bogo_info, $offered_product, $offer_product_id, $image_url, $regula
 					<div class="offer-product-image">
 						<img src="<?php echo esc_attr( $image_url ); ?>" width='70' alt="" />
 					</div>
-					<div class="offer-product-title" style="color: <?php echo esc_attr( $bogo_info->product_description_text_color ); ?>;
-															font-size: <?php echo esc_attr( $bogo_info->product_description_font_size ); ?>px;">
-						<h3 style="color: <?php echo esc_attr( $bogo_info->product_description_text_color ); ?>">
+					<div class="offer-product-title" style="color: <?php echo esc_attr( get_design_value( $bogo_info, 'product_description_text_color' ) ); ?>;
+															font-size: <?php echo esc_attr( get_design_value( $bogo_info, 'product_description_font_size' ) ); ?>px;">
+						<h3 style="color: <?php echo esc_attr( get_design_value( $bogo_info, 'product_description_text_color' ) ); ?>">
 							<?php echo esc_attr( get_the_title( $offer_product_id ) ); ?>
 						</h3>
 
@@ -65,7 +80,7 @@ if ( isset( $bogo_info, $offered_product, $offer_product_id, $image_url, $regula
 						?>
 
 						<?php if ( ! empty( $category_names ) ) : ?>
-							<p style="color: <?php echo esc_attr( $bogo_info->product_description_text_color ); ?>">
+							<p style="color: <?php echo esc_attr( get_design_value( $bogo_info, 'product_description_text_color' ) ); ?>">
 								<?php echo esc_html( $category_names ); ?>
 							</p>
 						<?php endif; ?>
@@ -74,8 +89,8 @@ if ( isset( $bogo_info, $offered_product, $offer_product_id, $image_url, $regula
 				<div
                     class="offer-price"
                     style="
-                        color: <?php echo esc_attr( $bogo_info->product_description_text_color ); ?>;
-                        font-size: <?php echo esc_attr( $bogo_info->product_description_font_size ); ?>px;
+                        color: <?php echo esc_attr( get_design_value( $bogo_info, 'product_description_text_color' ) ); ?>;
+                        font-size: <?php echo esc_attr( get_design_value( $bogo_info, 'product_description_font_size' ) ); ?>px;
                     "
                 >
 					<span style="text-decoration: line-through; display: <?php echo esc_attr( $show_regular_price ? 'inline-block' : 'none' ); ?>;">

--- a/modules/bogo/templates/bogo-product-meta-front-view.php
+++ b/modules/bogo/templates/bogo-product-meta-front-view.php
@@ -9,6 +9,14 @@
 use STOREGROWTH\SPSB\Modules\BoGo\Helper;
 
 if ( isset( $product, $bogo_info, $offered_product, $offer_product_id, $image_url, $regular_price, $offer_price ) ) {
+	// Simple helper function to get design values from JSON
+	function get_design_value( $bogo_info, $property ) {
+		if ( isset( $bogo_info->design_settings ) && is_string( $bogo_info->design_settings ) ) {
+			$design_data = json_decode( $bogo_info->design_settings, true );
+			return $design_data[ $property ] ?? '';
+		}
+		return '';
+	}
 	$bogo_message = $bogo_info->product_page_message;
 	$bogo_message = str_replace( '[offered_product]', get_the_title( $offered_product ), $bogo_message );
 	$bogo_message = str_replace( '[offered_product]', get_the_title( $offer_product_id ), $bogo_message );
@@ -17,11 +25,19 @@ if ( isset( $product, $bogo_info, $offered_product, $offer_product_id, $image_ur
 	?>
 
 	<div class='bogo-template-overview-area'>
-		<div class="offer-main-wrap" style="border: 2px solid #32DBBE; margin-bottom: 20px;">
-			<div class="dynamic-offer-text">
+		<div class="offer-main-wrap" style="
+			border: 2px <?php echo esc_attr( get_design_value( $bogo_info, 'box_border_style' ) ); ?> <?php echo esc_attr( get_design_value( $bogo_info, 'box_border_color' ) ); ?>;
+			margin-top: <?php echo esc_attr( get_design_value( $bogo_info, 'box_top_margin' ) ); ?>px;
+			margin-bottom: <?php echo esc_attr( get_design_value( $bogo_info, 'box_bottom_margin' ) ); ?>px;
+		">
+			<div class="dynamic-offer-text" style="
+				background: <?php echo esc_attr( get_design_value( $bogo_info, 'discount_background_color' ) ); ?>;
+				color: <?php echo esc_attr( get_design_value( $bogo_info, 'discount_text_color' ) ); ?>;
+				font-size: <?php echo esc_attr( get_design_value( $bogo_info, 'discount_font_size' ) ); ?>px;
+			">
 				<svg width='15' height='15' viewBox='0 0 12 12' fill='none' xmlns='http://www.w3.org/2000/svg'>
 					<path
-						fill='#02AC6E'
+						fill='<?php echo esc_attr( get_design_value( $bogo_info, 'discount_text_color' ) ); ?>'
 						d='M6.35818 0.158203C6.08866 0.158203 5.81928 0.261688 5.61466 0.466306L5.2127 0.868251C4.84967 1.23128 4.35705 1.43443 3.84365 1.43443H3.2095C2.63076 1.43443 2.15787 1.90729 2.15787 2.48604V2.95182V3.12053C2.15787 3.63394 1.95471 4.12619 1.59169 4.48922L1.18974 4.89117C0.780504 5.3004 0.780504 5.96965 1.18974 6.37888L1.59169 6.78083C1.95471 7.14386 2.15787 7.63577 2.15787 8.14918V8.78366C2.15787 9.36241 2.63076 9.83528 3.2095 9.83528H3.84365C4.35705 9.83528 4.84967 10.0388 5.2127 10.4018L5.61466 10.8034C6.02389 11.2126 6.69247 11.2126 7.1017 10.8034L7.504 10.4018C7.86703 10.0388 8.35931 9.83528 8.87271 9.83528H9.50686C10.0856 9.83528 10.5585 9.36241 10.5585 8.78366V8.14918C10.5585 7.63577 10.7634 7.14386 11.1264 6.78083L11.528 6.37888C11.9372 5.96964 11.9372 5.30041 11.528 4.89117L11.1264 4.48922C10.7634 4.12618 10.5585 3.63394 10.5585 3.12053V2.48604C10.5585 1.90729 10.0856 1.43443 9.50686 1.43443H8.87271C8.35931 1.43443 7.86703 1.23128 7.504 0.868251L7.1017 0.466306C6.89709 0.261687 6.6277 0.158204 6.35818 0.158203ZM5.03537 3.41518C5.52954 3.41518 5.93415 3.82012 5.93415 4.31429C5.93415 4.80846 5.52954 5.21341 5.03537 5.21341C4.54119 5.21341 4.13623 4.80846 4.13623 4.31429C4.13623 3.82012 4.54119 3.41518 5.03537 3.41518ZM8.13402 3.65669C8.18088 3.65643 8.22593 3.6748 8.25926 3.70775C8.27581 3.72405 8.28899 3.74346 8.29803 3.76486C8.30708 3.78625 8.31182 3.80923 8.31198 3.83246C8.31214 3.85569 8.30772 3.87873 8.29897 3.90025C8.29022 3.92177 8.27732 3.94136 8.261 3.95789L4.67896 7.56092C4.64604 7.59399 4.60137 7.6127 4.5547 7.61296C4.50804 7.61322 4.46315 7.59502 4.42986 7.56232C4.41325 7.54601 4.40004 7.52659 4.39096 7.50516C4.38188 7.48373 4.37713 7.46071 4.37697 7.43744C4.37681 7.41417 4.38124 7.39109 4.39002 7.36954C4.3988 7.34798 4.41175 7.32837 4.42812 7.31184L8.01015 3.70916C8.04292 3.67603 8.08743 3.65717 8.13402 3.65669ZM5.03537 3.76882C4.73224 3.76882 4.48988 4.0112 4.48988 4.31429C4.48988 4.61739 4.73224 4.85977 5.03537 4.85977C5.33849 4.85977 5.58085 4.61739 5.58085 4.31429C5.58085 4.0112 5.33849 3.76882 5.03537 3.76882ZM7.68134 6.05629C8.17552 6.05629 8.58047 6.46124 8.58047 6.95541C8.58047 7.44958 8.17552 7.85314 7.68134 7.85314C7.18717 7.85314 6.78359 7.44958 6.78359 6.95541C6.78359 6.46124 7.18717 6.05629 7.68134 6.05629ZM7.68134 6.40993C7.37822 6.40993 7.1369 6.65231 7.1369 6.95541C7.1369 7.2585 7.37822 7.50088 7.68134 7.50088C7.98447 7.50088 8.22648 7.2585 8.22648 6.95541C8.22648 6.65231 7.98447 6.40993 7.68134 6.40993Z'
 					/>
 				</svg>


### PR DESCRIPTION
## 🎯 **BOGO Design System: JSON Integration & Frontend Updates**

### ✨ **What Changed:**

- **Database Schema**: Migrated design fields from individual columns to single `design_settings` JSON column
- **Backend Logic**: Updated `BogoDataManager` to store/retrieve design settings as JSON
- **Frontend Templates**: Both BOGO templates now use JSON-based design system
- **Bug Fix**: Resolved PHP warning in `OrderBogo.php` causing card display issues

### 🔧 **Technical Details:**

- **JSON Storage**: All design properties (colors, fonts, margins, borders) stored in `design_settings` column
- **Helper Functions**: Clean `get_design_value()` function for template access
- **Template Updates**: `bogo-product-front-view.php` and `bogo-product-meta-front-view.php` updated
- **Data Flow**: Admin settings → JSON storage → Frontend rendering

### 🎨 **Design Fields:**

- Border styles, colors, margins
- Background colors, text colors, font sizes
- Product description styling
- Dynamic SVG fill colors

### ✅ **Benefits:**

- Cleaner database structure
- Easier to add new design properties
- Consistent frontend styling from admin settings
- Professional, maintainable code

### �� **Testing:**

- Re-activate plugin to update schema
- Verify BOGO cards display with admin design settings
- Check frontend matches admin preview exactly

---

**Files Modified:**
- `BogoDataManager.php` - JSON schema & data handling
- `bogo-product-front-view.php` - Template updates
- `bogo-product-meta-front-view.php` - Template updates  
- `OrderBogo.php` - Bug fix