### PR TITLE
Fix/flycart tax alignment

### DIFF
--- a/modules/fly-cart/assets/css/wfc-style.css
+++ b/modules/fly-cart/assets/css/wfc-style.css
@@ -660,7 +660,10 @@
 
 
 .sgsb-cart-collaterals.cart-collaterals .cart-subtotal td,
-.sgsb-cart-collaterals.cart-collaterals .order-total td {
+.sgsb-cart-collaterals.cart-collaterals .order-total td,
+.sgsb-cart-collaterals.cart-collaterals .tax-total td,
+.sgsb-cart-collaterals.cart-collaterals .tax-rate td,
+.sgsb-cart-collaterals.cart-collaterals tr[class*="tax"] td {
     text-align: right;
     padding: 0 !important;
     background: transparent !important;

--- a/modules/fly-cart/assets/css/wfc-style.css
+++ b/modules/fly-cart/assets/css/wfc-style.css
@@ -660,12 +660,12 @@
 
 
 .sgsb-cart-collaterals.cart-collaterals .cart-subtotal td,
-.spsb-cart-collaterals.cart-collaterals .order-total td,
-.spsb-cart-collaterals.cart-collaterals .tax-total td,
-.spsb-cart-collaterals.cart-collaterals .tax-rate td,
-.spsb-cart-collaterals.cart-collaterals tr[class*="tax"] td,
-.spsb-cart-collaterals.cart-collaterals .cart-discount td,
-.spsb-cart-collaterals.cart-collaterals tr[class*="coupon"] td {
+.spsg-cart-collaterals.cart-collaterals .order-total td,
+.spsg-cart-collaterals.cart-collaterals .tax-total td,
+.spsg-cart-collaterals.cart-collaterals .tax-rate td,
+.spsg-cart-collaterals.cart-collaterals tr[class*="tax"] td,
+.spsg-cart-collaterals.cart-collaterals .cart-discount td,
+.spsg-cart-collaterals.cart-collaterals tr[class*="coupon"] td {
     text-align: right;
     padding: 0 !important;
     background: transparent !important;

--- a/modules/fly-cart/assets/css/wfc-style.css
+++ b/modules/fly-cart/assets/css/wfc-style.css
@@ -663,7 +663,9 @@
 .sgsb-cart-collaterals.cart-collaterals .order-total td,
 .sgsb-cart-collaterals.cart-collaterals .tax-total td,
 .sgsb-cart-collaterals.cart-collaterals .tax-rate td,
-.sgsb-cart-collaterals.cart-collaterals tr[class*="tax"] td {
+.sgsb-cart-collaterals.cart-collaterals tr[class*="tax"] td,
+.sgsb-cart-collaterals.cart-collaterals .cart-discount td,
+.sgsb-cart-collaterals.cart-collaterals tr[class*="coupon"] td {
     text-align: right;
     padding: 0 !important;
     background: transparent !important;

--- a/modules/fly-cart/assets/css/wfc-style.css
+++ b/modules/fly-cart/assets/css/wfc-style.css
@@ -659,7 +659,7 @@
 }
 
 
-.sgsb-cart-collaterals.cart-collaterals .cart-subtotal td,
+.spsg-cart-collaterals.cart-collaterals .cart-subtotal td,
 .spsg-cart-collaterals.cart-collaterals .order-total td,
 .spsg-cart-collaterals.cart-collaterals .tax-total td,
 .spsg-cart-collaterals.cart-collaterals .tax-rate td,

--- a/modules/fly-cart/assets/css/wfc-style.css
+++ b/modules/fly-cart/assets/css/wfc-style.css
@@ -660,12 +660,12 @@
 
 
 .sgsb-cart-collaterals.cart-collaterals .cart-subtotal td,
-.sgsb-cart-collaterals.cart-collaterals .order-total td,
-.sgsb-cart-collaterals.cart-collaterals .tax-total td,
-.sgsb-cart-collaterals.cart-collaterals .tax-rate td,
-.sgsb-cart-collaterals.cart-collaterals tr[class*="tax"] td,
-.sgsb-cart-collaterals.cart-collaterals .cart-discount td,
-.sgsb-cart-collaterals.cart-collaterals tr[class*="coupon"] td {
+.spsb-cart-collaterals.cart-collaterals .order-total td,
+.spsb-cart-collaterals.cart-collaterals .tax-total td,
+.spsb-cart-collaterals.cart-collaterals .tax-rate td,
+.spsb-cart-collaterals.cart-collaterals tr[class*="tax"] td,
+.spsb-cart-collaterals.cart-collaterals .cart-discount td,
+.spsb-cart-collaterals.cart-collaterals tr[class*="coupon"] td {
     text-align: right;
     padding: 0 !important;
     background: transparent !important;

--- a/modules/fly-cart/includes/EnqueueScript.php
+++ b/modules/fly-cart/includes/EnqueueScript.php
@@ -186,7 +186,7 @@ class EnqueueScript implements HookRegistry {
 		wp_enqueue_script(
 			'wfc-script',
 			PluginHelper::get_modules_url( 'fly-cart/assets/js/wfc-script.js' ),
-			array( 'jquery' ),
+			array( 'jquery', 'wfc-flyto' ),
 			filemtime( PluginHelper::get_modules_path( 'fly-cart/assets/js/wfc-script.js' ) ),
 			true
 		);


### PR DESCRIPTION
Resolve the fly cart issue while Pro is activated and fix the alignment issue of the TAX and coupon row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Totals display: broadened styling so subtotal, tax lines, tax rates, discounts, coupons and order total align and display consistently.
  * Script loading: adjusted dependency order so the animation helper loads before the main cart script, improving reliability of the fly-to animation and preventing intermittent load/order issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->