### PR TITLE
refactor: fix license notice display and improve code structure

### DIFF
--- a/assets/src/components/pro-previews/Modules/FloatingNotificationBar/DisplayRules.js
+++ b/assets/src/components/pro-previews/Modules/FloatingNotificationBar/DisplayRules.js
@@ -35,7 +35,7 @@ const DisplayRules = () => {
           selectedOptions={['banner-show-desktop']}
           title={__("Show Banner", "storegrowth-sales-booster")}
           needUpgrade={true}
-          tooltip={__("Banner Dispaly in Devices", "storegrowth_sales_booster")}
+          tooltip={__("Banner Dispaly in Devices", "storegrowth-sales-booster")}
           showSingleCheckOverlay={false}
           headColSpan={16}
           checkboxColSpan={8}

--- a/assets/src/components/pro-previews/Modules/FreeShippingBar/DisplayRules.js
+++ b/assets/src/components/pro-previews/Modules/FreeShippingBar/DisplayRules.js
@@ -36,7 +36,7 @@ const DisplayRules = () => {
           selectedOptions={['banner-show-desktop']}
           title={__("Show Banner", "storegrowth-sales-booster")}
           needUpgrade={true}
-          tooltip={__("Banner Dispaly in Devices", "storegrowth_sales_booster")}
+          tooltip={__("Banner Dispaly in Devices", "storegrowth-sales-booster")}
           showSingleCheckOverlay={false}
           headColSpan={16}
           checkboxColSpan={8}

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -108,7 +108,7 @@ class AdminMenu {
 			array( $this, 'initial_setup_page_callback' )
 		);
 
-		if ( ! SPSG_PRO_ACTIVE ) {
+		if ( ! sp_store_growth()->has_pro() ) {
 			add_submenu_page(
 				'sales-booster-for-woocommerce',
 				__( 'Upgrade to Pro', 'storegrowth-sales-booster' ),

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -108,7 +108,7 @@ class AdminMenu {
 			array( $this, 'initial_setup_page_callback' )
 		);
 
-		if ( ! sp_store_growth()->has_pro() ) {
+		if ( ! sp_store_growth()->has_pro() && ! defined( 'STOREGROWTH_PRO_FILE' ) ) {
 			add_submenu_page(
 				'sales-booster-for-woocommerce',
 				__( 'Upgrade to Pro', 'storegrowth-sales-booster' ),

--- a/includes/Bootstrap.php
+++ b/includes/Bootstrap.php
@@ -30,6 +30,28 @@ class Bootstrap {
 	 * Constructor of Bootstrap class.
 	 */
 	private function __construct() {
+		add_action( 'woocommerce_loaded', [ $this, 'on_wc_loaded' ] );
+		add_action( 'admin_notices', [ $this, 'show_notice_if_wc_is_not_active' ] );
+	}
+
+	public function show_notice_if_wc_is_not_active(): void {
+		if ( function_exists( 'WC' ) ) {
+			return;
+		}
+
+		$message = sprintf(
+			// translators: %s is a placeholder for the WooCommerce plugin link.
+			__( 'StoreGrowth requires %s to be installed and active.', 'storegrowth_sales_booster' ),
+			'<a href="https://wordpress.org/plugins/woocommerce/">WooCommerce</a>'
+		);
+
+		printf( '<div class="%1$s"><p><strong>%2$s</strong></p></div>', esc_attr( 'notice notice-error' ), wp_kses_post( $message ) );
+	}
+
+	public function on_wc_loaded(): void {
+
+		do_action( 'storegrowth_before_load' );
+		
 		// Include module classes.
 		$this->load_module_classes();
 
@@ -47,6 +69,8 @@ class Bootstrap {
 
 		// Include integration classes.
 		$this->load_integration_classes();
+
+		do_action( 'storegrowth_loaded' );
 	}
 
 	/**
@@ -159,6 +183,6 @@ class Bootstrap {
 	 * @return boolean
 	 */
 	public function has_pro(): bool {
-		return SPSG_PRO_ACTIVE;
+		return apply_filters( 'spsg_pro_is_active', false );
 	}
 }

--- a/includes/Bootstrap.php
+++ b/includes/Bootstrap.php
@@ -41,7 +41,7 @@ class Bootstrap {
 
 		$message = sprintf(
 			// translators: %s is a placeholder for the WooCommerce plugin link.
-			__( 'StoreGrowth requires %s to be installed and active.', 'storegrowth_sales_booster' ),
+			__( 'StoreGrowth requires %s to be installed and active.', 'storegrowth-sales-booster' ),
 			'<a href="https://wordpress.org/plugins/woocommerce/">WooCommerce</a>'
 		);
 
@@ -51,7 +51,7 @@ class Bootstrap {
 	public function on_wc_loaded(): void {
 
 		do_action( 'storegrowth_before_load' );
-		
+
 		// Include module classes.
 		$this->load_module_classes();
 

--- a/includes/Bootstrap.php
+++ b/includes/Bootstrap.php
@@ -183,6 +183,6 @@ class Bootstrap {
 	 * @return boolean
 	 */
 	public function has_pro(): bool {
-		return apply_filters( 'spsg_pro_is_active', false );
+		return apply_filters( 'storegrowth_pro_is_active', false );
 	}
 }

--- a/integrations/includes/Dokan/REST/VendorBogoController.php
+++ b/integrations/includes/Dokan/REST/VendorBogoController.php
@@ -130,7 +130,7 @@ class VendorBogoController extends BogoController {
      */
     protected function check_creation_limitations( $data, $request ) {
         // Check for free version limitations specific to vendor
-        if ( ! SPSG_PRO_ACTIVE ) {
+        if ( ! sp_store_growth()->has_pro() ) {
             $vendor_id = dokan_get_current_user_id();
             $existing_offers = BogoDataManager::get_bogo_offers(['created_by' => $vendor_id]);
             if ( count( $existing_offers ) >= 2 ) {

--- a/modules/bogo/includes/REST/BogoController.php
+++ b/modules/bogo/includes/REST/BogoController.php
@@ -268,7 +268,7 @@ class BogoController extends WP_REST_Controller {
      */
     protected function check_creation_limitations( $data, $request ) {
         // Check for free version limitations
-        if ( ! SPSG_PRO_ACTIVE ) {
+        if ( ! sp_store_growth()->has_pro() ) {
             $existing_offers = BogoDataManager::get_global_bogo_offers();
             if ( count( $existing_offers ) >= 2 ) {
                 return new WP_Error(

--- a/modules/direct-checkout/includes/CommonHooks.php
+++ b/modules/direct-checkout/includes/CommonHooks.php
@@ -72,7 +72,7 @@ class CommonHooks implements HookRegistry {
 	 * @return string
 	 */
 	public function show_signle_direct_checkout_button_shop( $add_to_cart ) {
-		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) && SPSG_PRO_ACTIVE ) {
+		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) && sp_store_growth()->has_pro() ) {
 			ob_start();
 			global $product;
 			$product_id                    = get_the_ID();
@@ -107,7 +107,7 @@ class CommonHooks implements HookRegistry {
 	 * @return string
 	 */
 	public function show_direct_checkout_button_shop( $add_to_cart ) {
-		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) && SPSG_PRO_ACTIVE ) {
+		if ( $this->should_display_buy_now_button( 'shop_page_checkout_enable' ) && sp_store_growth()->has_pro() ) {
 			ob_start();
 			$this->display_buy_now_button();
 			$buy_now_button = ob_get_contents();

--- a/modules/floating-notification-bar/assets/src/components/DisplayRules.js
+++ b/modules/floating-notification-bar/assets/src/components/DisplayRules.js
@@ -69,7 +69,7 @@ const DisplayRules = (props) => {
           handleCheckboxChange={onFieldChange}
           title={__("Show Banner", "storegrowth-sales-booster")}
           needUpgrade={upgradeTeaser}
-          tooltip={__("Banner Dispaly in Devices", "storegrowth_sales_booster")}
+          tooltip={__("Banner Dispaly in Devices", "storegrowth-sales-booster")}
           headColSpan={16}
           checkboxColSpan={8}
           showProIcon={false}

--- a/modules/fly-cart/includes/EnqueueScript.php
+++ b/modules/fly-cart/includes/EnqueueScript.php
@@ -71,7 +71,7 @@ class EnqueueScript implements HookRegistry {
 		$this->frontend_widget_script();
 		$this->qc_basic_inline_styles();
 
-		if ( 'center' === $layout && SPSG_PRO_ACTIVE ) {
+		if ( 'center' === $layout && sp_store_growth()->has_pro() ) {
 				do_action( 'spsg_ffc_wp_enqueue_scripts' );
 		} else {
 				$this->qc_side_cart_styles();

--- a/modules/fly-cart/templates/fly-cart.php
+++ b/modules/fly-cart/templates/fly-cart.php
@@ -96,7 +96,7 @@ $action_btn_active_bg = \StorePulse\StoreGrowth\Helper::find_option_settings( $s
 </div>
 
 <div class="wfc-overlay wfc-hide"></div>
-<div class="wfc-widget-sidebar <?php echo esc_attr( SPSG_PRO_ACTIVE ? $class_name : '' ); ?> wfc-slide ">
+<div class="wfc-widget-sidebar <?php echo esc_attr( sp_store_growth()->has_pro() ? $class_name : '' ); ?> wfc-slide ">
 <span class="qc-close-nav">
 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="8" viewBox="0 0 14 8" fill="none">
 <path d="M1 1L4.72223 5.3426C5.91952 6.73944 8.08048 6.73944 9.27777 5.3426L13 1" stroke="#073B4C" stroke-width="2" stroke-linecap="round"/>

--- a/modules/quick-view/templates/quick-view-button.php
+++ b/modules/quick-view/templates/quick-view-button.php
@@ -29,7 +29,7 @@ $is_icon_active        = \StorePulse\StoreGrowth\Helper::find_option_settings( $
 
 <a href="#" data-id="<?php echo absint( $product_id ); ?>" data-context="default" data-effect="<?php echo esc_attr( $modal_effect ); ?>" class="<?php echo esc_attr( $classes ); ?>" rel="nofollow">
 <?php
-if ( $is_icon_active && SPSG_PRO_ACTIVE ) {
+if ( $is_icon_active && sp_store_growth()->has_pro() ) {
 	do_action( 'spsg_quick_view_icon_button', $quick_view_icon_color );
 } else {
 	echo esc_html( sprintf( '%1$s', $button_label ) );

--- a/storegrowth-sales-booster.php
+++ b/storegrowth-sales-booster.php
@@ -9,7 +9,10 @@
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain: storegrowth-sales-booster
  * Domain Path: /languages
- *
+ * Requires Plugins: woocommerce
+ * Requires at least: 6.8
+ * Requires PHP: 7.4
+ * 
  * @package SPSG
  */
 

--- a/storegrowth-sales-booster.php
+++ b/storegrowth-sales-booster.php
@@ -54,7 +54,6 @@ if ( ! defined( 'STOREGROWTH_MODULE_DIR' ) ) {
 	define( 'STOREGROWTH_MODULE_DIR', __DIR__ . '/modules' );
 }
 
-
 /**
  * Define plugin basename.
  */
@@ -62,33 +61,6 @@ if ( ! defined( 'STOREGROWTH_BASENAME' ) ) {
 	define( 'STOREGROWTH_BASENAME', plugin_basename( STOREGROWTH_FILE ) );
 }
 
-/**
- * Check free plugin is active or not.
- */
-require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-if ( ! is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
-	add_action(
-		'admin_notices',
-		function () {
-			$message = sprintf(
-					// translators: %s is a placeholder for the WooCommerce plugin link.
-				__( 'StoreGrowth requires %s to be installed and active.', 'storegrowth_sales_booster' ),
-				'<a href="https://wordpress.org/plugins/woocommerce/">WooCommerce</a>'
-			);
-
-			printf( '<div class="%1$s"><p><strong>%2$s</strong></p></div>', esc_attr( 'notice notice-error' ), wp_kses_post( $message ) );
-		}
-	);
-
-	return;
-}
-
-if ( is_plugin_active( 'storegrowth-sales-booster-pro/storegrowth-sales-booster-pro.php' ) ) {
-	defined( 'SPSG_PRO_ACTIVE' ) || define( 'SPSG_PRO_ACTIVE', true );
-} else {
-	defined( 'SPSG_PRO_ACTIVE' ) || define( 'SPSG_PRO_ACTIVE', false );
-}
 
 /**
  * add option when plugin is activated.


### PR DESCRIPTION
## Summary
This PR fixes the license notice display issues and improves the overall code structure across multiple modules.

## Changes Made
- Fixed license notice display in admin menu and bootstrap files
- Improved code structure in BOGO module REST controllers
- Enhanced direct checkout common hooks
- Updated fly cart enqueue script and templates
- Refined quick view button template
- General code cleanup and optimization

## Files Modified
- `includes/Admin/AdminMenu.php`
- `includes/Bootstrap.php`
- `integrations/includes/Dokan/REST/VendorBogoController.php`
- `modules/bogo/includes/REST/BogoController.php`
- `modules/direct-checkout/includes/CommonHooks.php`
- `modules/fly-cart/includes/EnqueueScript.php`
- `modules/fly-cart/templates/fly-cart.php`
- `modules/quick-view/templates/quick-view-button.php`
- `storegrowth-sales-booster.php`

## Testing
- [ ] License notices display correctly in admin area
- [ ] All modules function as expected
- [ ] No breaking changes introduced

## Type of Change
- [x] Bug fix
- [x] Code refactoring
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Admin notice added to prompt installation/activation of WooCommerce when missing.

- Bug Fixes
  - More reliable Pro detection ensuring correct behavior for:
    - “Upgrade to Pro” menu visibility
    - Buy Now / Direct Checkout buttons
    - Fly Cart layout
    - Quick View icon rendering
    - BOGO creation limits
  - Fixed translation domain for several preview/tooltips.

- Refactor
  - Switched from a static flag to dynamic runtime Pro checks and added load lifecycle hooks.

- Chores
  - Plugin header now declares required WooCommerce and PHP versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->