### PR TITLE
fix: improve fly cart styling and script dependencies

### DIFF
--- a/modules/fly-cart/assets/css/wfc-style.css
+++ b/modules/fly-cart/assets/css/wfc-style.css
@@ -658,9 +658,13 @@
     color: rgb(0, 0, 0) !important;
 }
 
-
 .spsg-cart-collaterals.cart-collaterals .cart-subtotal td,
-.spsg-cart-collaterals.cart-collaterals .order-total td {
+.spsg-cart-collaterals.cart-collaterals .order-total td,
+.spsg-cart-collaterals.cart-collaterals .tax-total td,
+.spsg-cart-collaterals.cart-collaterals .tax-rate td,
+.spsg-cart-collaterals.cart-collaterals tr[class*="tax"] td,
+.spsg-cart-collaterals.cart-collaterals .cart-discount td,
+.spsg-cart-collaterals.cart-collaterals tr[class*="coupon"] td {
     text-align: right;
     padding: 0 !important;
     background: transparent !important;

--- a/modules/fly-cart/includes/EnqueueScript.php
+++ b/modules/fly-cart/includes/EnqueueScript.php
@@ -186,7 +186,7 @@ class EnqueueScript implements HookRegistry {
 		wp_enqueue_script(
 			'wfc-script',
 			PluginHelper::get_modules_url( 'fly-cart/assets/js/wfc-script.js' ),
-			array( 'jquery' ),
+			array( 'jquery', 'wfc-flyto' ),
 			filemtime( PluginHelper::get_modules_path( 'fly-cart/assets/js/wfc-script.js' ) ),
 			true
 		);


### PR DESCRIPTION
## Summary
This PR fixes styling issues in the fly cart module and improves script dependencies for better functionality.

## Changes Made
- **CSS Improvements**: Enhanced cart collaterals styling for tax, discount, and coupon rows
- **Script Dependencies**: Added proper dependency for `wfc-flyto` script in fly cart
- **Styling Consistency**: Improved CSS selector coverage for all cart table elements
- **Text Alignment**: Ensured consistent right-alignment for cart totals and related elements

## Technical Details

### CSS Changes (`modules/fly-cart/assets/css/wfc-style.css`)
- Extended CSS selectors to cover tax, discount, and coupon rows
- Added support for:
  - `.tax-total td`
  - `.tax-rate td` 
  - `tr[class*="tax"] td`
  - `.cart-discount td`
  - `tr[class*="coupon"] td`
- Ensured consistent styling across all cart table elements

### Script Changes (`modules/fly-cart/includes/EnqueueScript.php`)
- Added `wfc-flyto` as a dependency for the main fly cart script
- Ensures proper script loading order and functionality

## Benefits
- ✅ Better visual consistency in fly cart
- ✅ Proper script dependency management
- ✅ Improved styling for tax and discount elements
- ✅ Enhanced user experience in cart interactions

## Testing
- [ ] Fly cart displays correctly with tax calculations
- [ ] Discount and coupon styling is consistent
- [ ] Script dependencies load in correct order
- [ ] Cart totals are properly aligned
- [ ] All cart elements maintain consistent styling

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Consistent presentation in the fly-cart: right-aligned totals with updated padding/background now applied to totals, taxes, discounts, and coupon rows.
* **Bug Fixes**
  * Improved fly-cart reliability by updating frontend script dependencies to ensure required components load in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->