### PR TITLE
Add vendor info display to Fly Cart with Dokan integration

### DIFF
--- a/integrations/assets/src/dokan/admin/flycart/VendorInfo.tsx
+++ b/integrations/assets/src/dokan/admin/flycart/VendorInfo.tsx
@@ -7,7 +7,9 @@ const VendorInfo = ({storeData}) => {
     return (
         <div>
             <strong>{__('Vendor ', 'dokan')}:</strong>
-            {__('Bright Star Market', 'dokan')}
+            <span style={ storeData?.enable_quick_cart_dokan_store_links ? {textDecoration: 'underline'} : {} }>
+                {__('Bright Star Market', 'dokan')}
+            </span>
         </div>
     );
 }

--- a/integrations/assets/src/dokan/admin/flycart/VendorInfo.tsx
+++ b/integrations/assets/src/dokan/admin/flycart/VendorInfo.tsx
@@ -1,0 +1,15 @@
+import {__} from "@wordpress/i18n";
+
+const VendorInfo = ({storeData}) => {
+    if (!storeData?.show_quick_cart_dokan_store_names) {
+        return null
+    }
+    return (
+        <div>
+            <strong>{__('Vendor ', 'dokan')}:</strong>
+            {__('Bright Star Market', 'dokan')}
+        </div>
+    );
+}
+
+export default VendorInfo;

--- a/integrations/assets/src/dokan/admin/flycart/VendorInfoPreview.tsx
+++ b/integrations/assets/src/dokan/admin/flycart/VendorInfoPreview.tsx
@@ -1,6 +1,6 @@
 import {__} from "@wordpress/i18n";
 
-const VendorInfo = ({storeData}) => {
+const VendorInfoPreview = ({storeData}) => {
     if (!storeData?.show_quick_cart_dokan_store_names) {
         return null
     }
@@ -14,4 +14,4 @@ const VendorInfo = ({storeData}) => {
     );
 }
 
-export default VendorInfo;
+export default VendorInfoPreview;

--- a/integrations/assets/src/dokan/admin/flycart/index.tsx
+++ b/integrations/assets/src/dokan/admin/flycart/index.tsx
@@ -1,6 +1,6 @@
 import { addFilter } from "@wordpress/hooks";
 import { __ } from "@wordpress/i18n";
-import VendorInfo from "./VendorInfo";
+import VendorInfoPreview from "./VendorInfoPreview";
 
 addFilter(
   "spsg_quick_cart_content_settings",
@@ -31,5 +31,5 @@ addFilter("spsg_quick_cart_state", "spsg_quick_cart_state_callback", (data) => {
 addFilter(
     'spsg_cart_product_detail_after',
     'spsg_fly_cart_product_detail_after_callback',
-    (data, storeData) => <VendorInfo storeData={storeData} />
+    (data, storeData) => <VendorInfoPreview storeData={storeData} />
 )

--- a/integrations/assets/src/dokan/admin/flycart/index.tsx
+++ b/integrations/assets/src/dokan/admin/flycart/index.tsx
@@ -1,5 +1,6 @@
 import { addFilter } from "@wordpress/hooks";
 import { __ } from "@wordpress/i18n";
+import VendorInfo from "./VendorInfo";
 
 addFilter(
   "spsg_quick_cart_content_settings",
@@ -26,3 +27,9 @@ addFilter("spsg_quick_cart_state", "spsg_quick_cart_state_callback", (data) => {
     enable_quick_cart_dokan_store_links: true,
   };
 });
+
+addFilter(
+    'spsg_cart_product_detail_after',
+    'spsg_fly_cart_product_detail_after_callback',
+    (data, storeData) => <VendorInfo storeData={storeData} />
+)

--- a/integrations/includes/Dokan/Dokan.php
+++ b/integrations/includes/Dokan/Dokan.php
@@ -14,7 +14,7 @@ use StorePulse\StoreGrowth\Interfaces\HookRegistry;
  */
 class Dokan implements HookRegistry {
     public function register_hooks(): void {
-        add_action( 'dokan_loaded', [ $this, 'init_classes' ] );
+        $this->init_classes();
     }
 
     /**

--- a/modules/fly-cart/assets/src/components/Preview.js
+++ b/modules/fly-cart/assets/src/components/Preview.js
@@ -241,6 +241,7 @@ const Preview = ( { storeData } ) => {
                                         </div>
                                     ) }
                                     </div>
+                                        { applyFilters('spsg_cart_product_detail_after', '', storeData) }
                                     </div> 
                                 </div>
                                 <div
@@ -381,6 +382,7 @@ const Preview = ( { storeData } ) => {
                                         </div>
                                     ) }
                                     </div>
+                                        { applyFilters('spsg_cart_product_detail_after', '', storeData) }
                                     </div> 
                                 </div>
                                 


### PR DESCRIPTION
Introduces a new VendorInfo component to show vendor names in the Fly Cart when Dokan store names are enabled. Hooks are added to render this info after product details in the cart preview. Also updates Dokan hook registration to call init_classes directly.

* Closes https://github.com/getdokan/plugin-internal-tasks/issues/905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Quick Cart now displays the vendor name for each item when the corresponding setting is enabled.
  * Vendor names can optionally appear as links to the vendor’s store, based on your settings.
  * Added new extension points in the cart item details to allow additional content after product information, enabling richer per-item details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->