### PR TITLE
Update offer_type enum and description in OrderBumpController

### DIFF
--- a/modules/upsell-order-bump/includes/RestApi/OrderBumpController.php
+++ b/modules/upsell-order-bump/includes/RestApi/OrderBumpController.php
@@ -445,9 +445,9 @@ class OrderBumpController extends WP_REST_Controller {
 					'required'    => true,
 				),
 				'offer_type'        => array(
-					'description' => __( 'Type of offer (discount or fixed_price).', 'storegrowth-sales-booster' ),
+					'description' => __( 'Type of offer (discount or price).', 'storegrowth-sales-booster' ),
 					'type'        => 'string',
-					'enum'        => array( 'discount', 'fixed_price' ),
+					'enum'        => array( 'discount', 'price' ),
 					'context'     => array( 'view', 'edit' ),
 					'default'     => 'discount',
 				),


### PR DESCRIPTION
Changed the 'offer_type' parameter description and allowed values from 'fixed_price' to 'price' to better reflect the available options.

## Closes
* https://github.com/getdokan/storegrowth-sales-booster-pro/issues/167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated API validation for offer_type to accept “discount” or “price” (replacing “fixed_price”). Requests using “fixed_price” should switch to “price.”

- Documentation
  - Clarified offer_type description to reflect the new allowed values (“discount” or “price”).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->