### PR TITLE
Update YouTube video in dashboard overview

### DIFF
--- a/assets/src/components/dashboard/Overview.js
+++ b/assets/src/components/dashboard/Overview.js
@@ -38,7 +38,7 @@ const Overview = () => {
                     {/* intro-section */}
                     <div className="intro-section">
                       <div className="intro-section-banner">
-                      <iframe height="315" src="https://www.youtube.com/embed/UPGtOEsY2kI?si=bAw1ZMxwhCTIvsCH" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+                      <iframe height="315" src="https://www.youtube.com/embed/MFcXkKzaGwM?si=a_MytNUMuTa8MYHw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
                       </div>
                     </div>
 


### PR DESCRIPTION
Replaced the embedded YouTube video in the Overview component with a new video source. This updates the intro section banner to display the new video.

## Closes
* https://github.com/getdokan/storegrowth-sales-booster-pro/issues/168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the dashboard’s intro banner to use a new YouTube video, refreshing the embedded content for improved relevance while keeping the same viewing experience (controls/behavior unchanged).
  - Users will see the new video immediately; no action required.
  - This is a content-only change with no functional impact on navigation, settings, or other dashboard features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->