### PR TITLE
Update button style label and add conditional check for button styles

### DIFF
--- a/modules/direct-checkout/assets/src/components/Design.js
+++ b/modules/direct-checkout/assets/src/components/Design.js
@@ -39,7 +39,7 @@ function Design({ onFormSave, upgradeTeaser }) {
           name={ 'button_style' }
           changeHandler={ onFieldChange }
           isEnable={ Boolean( createDirectCheckoutFormData.button_style ) }
-          title={ __( 'Button Style', 'storegrowth-sales-booster' ) }
+          title={ __( 'Custom Button Style', 'storegrowth-sales-booster' ) }
           tooltip={ __( 'Will be able to achieve the control of the button style in the product.', 'storegrowth-sales-booster' ) }
         />
 

--- a/modules/direct-checkout/includes/EnqueueScript.php
+++ b/modules/direct-checkout/includes/EnqueueScript.php
@@ -107,6 +107,10 @@ class EnqueueScript implements HookRegistry {
 	private function dc_button_inline_styles() {
 		// Get style options.
 		$settings             = \StorePulse\StoreGrowth\Helper::get_settings( 'spsg_direct_checkout_settings' );
+		$button_style         = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'button_style', true );
+        if ( ! $button_style ) {
+            return;
+        }
 		$button_color         = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'button_color', '#008dff' );
 		$text_color           = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'text_color', '#ffffff' );
 		$font_size            = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'font_size', '16' );


### PR DESCRIPTION
### Closes
* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/116

### How to test the changes in this Pull Request:
- Test as mentioned in the issue

### Changelog entry
```text
- **update:** Update button style setting label in direct checkout admin setting.
- **fix:** Added conditional check for button styles for direct checkout button.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Disabling Custom Button Style now fully prevents inline button styles from loading, avoiding unintended overrides to button color, text color, font size, and border radius. This improves consistency with theme styles and can reduce unnecessary CSS on the page.

* Style
  * Updated the UI label to “Custom Button Style” in the Direct Checkout design settings for clearer wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->