### PR TITLE
fix: correct module path casing in dashboard template inclusion

### DIFF
--- a/integrations/includes/Dokan/Dashboard/Dashboard.php
+++ b/integrations/includes/Dokan/Dashboard/Dashboard.php
@@ -114,7 +114,7 @@ class Dashboard {
         ];
 
         // Include the template file directly with variables in scope
-        include STOREGROWTH_DIR_PATH . '/Modules/countdown-timer/templates/dokan-countdown-timer-fields.php';
+        include STOREGROWTH_DIR_PATH . '/modules/countdown-timer/templates/dokan-countdown-timer-fields.php';
     }
 
     /**


### PR DESCRIPTION
* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the countdown timer fields in the Dashboard might not load on certain environments due to directory name casing. The template now loads reliably across systems with case-sensitive file structures. No functional, UI, or behavioral changes otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->