### PR TITLE
feat: Support countdown timer for variable products

### DIFF
--- a/modules/countdown-timer/includes/CommonHooks.php
+++ b/modules/countdown-timer/includes/CommonHooks.php
@@ -36,7 +36,7 @@ class CommonHooks implements HookRegistry {
 		add_action( 'woocommerce_admin_process_product_object', array( $this, 'woocommerce_admin_process_product_object' ) );
 
 		add_filter( 'woocommerce_product_get_price', array( $this, 'get_product_price' ), 10, 2 );
-
+		add_filter( 'woocommerce_product_variation_get_price', array( $this, 'get_product_price' ), 10, 2 );
 		add_filter( 'woocommerce_product_is_on_sale', array( $this, 'woocommerce_product_is_on_sale' ), 10, 2 );
 	}
 
@@ -109,10 +109,13 @@ class CommonHooks implements HookRegistry {
 
 		$stock_discount_amount = isset( $_POST['_spsg_countdown_timer_discount_amount'] ) ? wc_clean( wp_unslash( $_POST['_spsg_countdown_timer_discount_amount'] ) ) : null; // phpcs:ignore
 
-		update_post_meta( $product->get_id(), '_spsg_countdown_timer_discount_start', $discount_start_date );
-		update_post_meta( $product->get_id(), '_spsg_countdown_timer_discount_end', $discount_end_date );
-		update_post_meta( $product->get_id(), '_spsg_countdown_timer_discount_amount', $stock_discount_amount );
+		$product_ids = array_merge( [ $product->get_id() ], $product->get_children() );
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
+		foreach( $product_ids as $product_id ) {
+			update_post_meta( $product_id, '_spsg_countdown_timer_discount_start', $discount_start_date );
+			update_post_meta( $product_id, '_spsg_countdown_timer_discount_end', $discount_end_date );
+			update_post_meta( $product_id, '_spsg_countdown_timer_discount_amount', $stock_discount_amount );
+		}
 	}
 
 	/**

--- a/modules/countdown-timer/includes/CommonHooks.php
+++ b/modules/countdown-timer/includes/CommonHooks.php
@@ -48,9 +48,9 @@ class CommonHooks implements HookRegistry {
 		global $product;
 		$stock_status = $product->get_stock_status();
 
-		$supported_types = apply_filters( 'spsg_countdown_timer_supported_product_type', [ 'simple', 'variable' ] );
+		$is_allow = apply_filters( 'spsg_allow_countdown_timer_render', true, $product );
 
-		if ( in_array( $product->get_type(), $supported_types, true ) && 'outofstock' !== $stock_status ) {
+		if ( $is_allow && 'outofstock' !== $stock_status ) {
 			include __DIR__ . '/../templates/countdown-timer.php';
 		}
 	}

--- a/modules/countdown-timer/includes/CommonHooks.php
+++ b/modules/countdown-timer/includes/CommonHooks.php
@@ -8,6 +8,7 @@
 namespace StorePulse\StoreGrowth\Modules\CountdownTimer;
 
 use StorePulse\StoreGrowth\Interfaces\HookRegistry;
+use WC_Product;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -43,9 +44,13 @@ class CommonHooks implements HookRegistry {
 	 * Hook for WooCommerce before add-to-cart form.
 	 */
 	public function show_countdown_timer_template() {
+		/** @var WC_Product $product */
 		global $product;
 		$stock_status = $product->get_stock_status();
-		if ( $product->is_type( 'simple' ) && 'outofstock' !== $stock_status ) {
+
+		$supported_types = apply_filters( 'spsg_countdown_timer_supported_product_type', [ 'simple', 'variable' ] );
+
+		if ( in_array( $product->get_type(), $supported_types, true ) && 'outofstock' !== $stock_status ) {
 			include __DIR__ . '/../templates/countdown-timer.php';
 		}
 	}


### PR DESCRIPTION
* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/133
* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Countdown timer now displays for more product types (not limited to simple products) when items are in stock.
  * Merchants can configure which products show countdowns via a new eligibility setting.

* **Bug Fixes / Improvements**
  * Countdown and promotional discounts now apply consistently to variations and child products, and admin updates propagate to them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->