### PR TITLE
Feat/order bump qty validation

### DIFF
--- a/modules/upsell-order-bump/includes/OrderBumpAjax.php
+++ b/modules/upsell-order-bump/includes/OrderBumpAjax.php
@@ -61,7 +61,7 @@ class OrderBumpAjax implements HookRegistry {
 		} else {
 			$custom_price = $bump_price;
 			// Cart item data to send & save in order.
-			$cart_item_data = array( 'custom_price' => $custom_price );
+			$cart_item_data = array( 'custom_price' => $custom_price, '_spsg_order_bump_product' => true );
 			// Woocommerce function to add product into cart check its documentation also.
 			$woocommerce->cart->add_to_cart( $offer_product_id, 1, $offer_variation_id, $variation = array(), $cart_item_data );
 			// Calculate totals.

--- a/modules/upsell-order-bump/includes/Providers/BootstrapServiceProvider.php
+++ b/modules/upsell-order-bump/includes/Providers/BootstrapServiceProvider.php
@@ -8,6 +8,7 @@ use StorePulse\StoreGrowth\Modules\UpsellOrderBump\EnqueueScript;
 use StorePulse\StoreGrowth\Modules\UpsellOrderBump\OrderBump;
 use StorePulse\StoreGrowth\Modules\UpsellOrderBump\OrderBumpAjax;
 use StorePulse\StoreGrowth\Modules\UpsellOrderBump\RestApi\OrderBumpController;
+use StorePulse\StoreGrowth\Modules\UpsellOrderBump\Validators\CartValidator;
 
 /**
  * BootstrapServiceProvider for the module.
@@ -32,6 +33,7 @@ class BootstrapServiceProvider extends BootableServiceProvider {
         OrderBump::class,
         OrderBumpAjax::class,
         OrderBumpController::class,
+	    CartValidator::class,
     ];
 
     /**

--- a/modules/upsell-order-bump/includes/Validators/CartValidator.php
+++ b/modules/upsell-order-bump/includes/Validators/CartValidator.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace StorePulse\StoreGrowth\Modules\UpsellOrderBump\Validators;
+
+use StorePulse\StoreGrowth\Interfaces\HookRegistry;
+use WP_Error;
+
+class CartValidator implements HookRegistry {
+
+	private array $errors = [];
+
+	public function register_hooks(): void {
+		add_filter( 'woocommerce_cart_item_quantity', [ $this, 'maybe_disable_cart_item_quantity' ], 8, 3 );
+		add_action( 'woocommerce_after_checkout_validation', [ $this, 'after_checkout_validation' ], 10, 2 );
+		add_action( 'woocommerce_store_api_cart_errors', [ $this, 'should_render_validation_error' ] );
+	}
+
+	/**
+	 * Remove the quantity field
+	 *
+	 * @param $quantity
+	 * @param $cart_item_key
+	 * @param $cart_item
+	 *
+	 * @return string
+	 */
+	public function maybe_disable_cart_item_quantity( $quantity, $cart_item_key, $cart_item ) {
+		// Check if custom data exists
+		if ( isset( $cart_item['_spsg_order_bump_product'] ) ) {
+			// Show non-editable quantity
+			return sprintf( '<span class="fixed-qty">%d</span>', $cart_item['quantity'] );
+		}
+
+		return $quantity;
+	}
+
+	public function after_checkout_validation( $data, WP_Error $errors ) {
+		$this->should_render_validation_error( $errors );
+	}
+
+	/**
+	 * Check if the cart is invalid
+	 *
+	 * @return bool
+	 */
+	public function is_invalid_cart(): bool {
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+			if ( isset( $cart_item['_spsg_order_bump_product'] ) && $cart_item['quantity'] > 1 ) {
+
+				$this->errors[] = [
+					'type'    => 'error',
+					'message' => sprintf( 'Maximum allowed quantity for %s', $this->get_product_with_link( $cart_item['product_id'] ) )
+				];
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	protected function get_product_with_link( $product_id ): string {
+		$product = wc_get_product( $product_id );
+
+		return wp_kses(
+			"<a href='{$product->get_permalink()}'>{$product->get_title()}</a>",
+			[
+				'a' => [
+					'href'  => [],
+					'title' => [],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Handle the block api validation error
+	 *
+	 * @param WP_Error $wp_error
+	 *
+	 * @return void
+	 */
+	public function should_render_validation_error( WP_Error $wp_error ) {
+		if ( $this->is_invalid_cart() ) {
+			foreach ( $this->errors as $error ) {
+				$wp_error->add( $error['type'], $error['message'] );
+			}
+		}
+	}
+}

--- a/modules/upsell-order-bump/includes/Validators/CartValidator.php
+++ b/modules/upsell-order-bump/includes/Validators/CartValidator.php
@@ -34,8 +34,8 @@ class CartValidator implements HookRegistry {
 		return $quantity;
 	}
 
-	public function after_checkout_validation( $data, WP_Error $errors ) {
-		$this->should_render_validation_error( $errors );
+	public function after_checkout_validation( $data, WP_Error $error ) {
+		$this->maybe_render_validation_error( $error );
 	}
 
 	/**
@@ -80,7 +80,7 @@ class CartValidator implements HookRegistry {
 	 *
 	 * @return void
 	 */
-	public function should_render_validation_error( WP_Error $wp_error ) {
+	public function maybe_render_validation_error( WP_Error $wp_error ) {
 		if ( $this->is_invalid_cart() ) {
 			foreach ( $this->errors as $error ) {
 				$wp_error->add( $error['type'], $error['message'] );


### PR DESCRIPTION
* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order bump items are now clearly identified in the cart.
  * Quantity controls for order bump items are disabled to prevent edits.
  * Clear, user-friendly error messages appear during checkout and via the Store API when cart rules are violated.

* **Bug Fixes**
  * Prevents setting quantity greater than 1 for order bump items, ensuring consistent cart behavior and checkout validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->