### PR TITLE
Add RadioGroup component and update checkout redirect UI

### DIFF
--- a/assets/src/components/settings/Panels/PanelSettings/Fields/RadioGroup.js
+++ b/assets/src/components/settings/Panels/PanelSettings/Fields/RadioGroup.js
@@ -1,0 +1,169 @@
+import React from "react";
+import { Radio, Col, Space, Typography } from "antd";
+import FieldWrapper from "./FieldWrapper";
+import SettingsTooltip from "../SettingsTooltip";
+import UpgradeCrown from "../UpgradeCrown";
+import UpgradeOverlay from "../UpgradeOverlay";
+const { Title } = Typography;
+
+/**
+ * RadioGroup Component
+ *
+ * This component is designed for handling a group of radio group that control a single setting.
+ * It provides the ability to select multiple options or switch to a single option mode, where only
+ * one option can be selected at a time.
+ *
+ * @param {string} name - The name of the setting associated with the radio group.
+ * @param {string} title - The title or label to display for the group of radio group.
+ * @param {array} options - An array of objects representing the available radio group options.
+ * @param {array} selectedOptions - An array of selected options (values) from the radio group.
+ * @param {function} handleChange - A callback function to handle changes in radio group selections.
+ * @param {boolean} isSingleMode - A boolean flag indicating whether to allow only one option to be selected at a time.
+ * @param {number} colSpan - The number of columns to span for layout (default is 24 for full width).
+ * @param {number} headColSpan - The number of columns to span for the header (default is 15).
+ * @param {number} radioColSpan - The number of columns to span for the radio group (default is 9).
+ * @param {string} displayDirection - The direction to display the options, either "vertical" or "horizontal" (default is "vertical").
+ * @param {string} tooltip - An optional tooltip to display next to the title.
+ * @param {boolean} needUpgrade - A boolean flag indicating whether this setting requires an upgrade.
+ * @param {boolean} showProIcon - A boolean flag to show or hide the pro icon for options that need an upgrade (default is true).
+ * @param {boolean} showSingleCheckOverlay - A boolean flag to show or hide the upgrade overlay for options that need an upgrade (default is true).
+ * @param {ReactNode} children - Optional children elements to render below the radio group.
+ *
+ * Usage:
+ * ```jsx
+ * <RadioGroup
+ *   name="exampleSetting"
+ *   title="Example Setting"
+ *   options={[
+ *     {
+      label: `"Add to cart" as "Buy Now"`,
+      value: "cart-to-buy-now",
+      needUpgrade: upgradeTeaser,
+      tooltip: __(
+        "Use the add to cart button as the buy now button",
+        "storegrowth-sales-booster"
+      ),
+    },
+    {
+      label: `"Buy Now" with "Add to cart"`,
+      value: "cart-with-buy-now",
+      tooltip: __("", "storegrowth-sales-booster"),
+    },
+ *     // Add more options as needed
+ *   ]}
+ *   selectedOptions={selectedOptions}
+ *   handleChange={handleChange}
+ *   isSingleMode={false}
+ *   colSpan={24}
+ * />
+ * ```
+ *
+ * In the example above:
+ * - `name`: The name of the setting associated with these radio group.
+ * - `title`: The title or label for this group of radio group.
+ * - `options`: An array of radio group options, where each option is an object with a label, value, and an optional needUpgrade flag.
+ * - `selectedOptions`: An array of currently selected options (values).
+ * - `handleChange`: A callback function that will be called when radio selections change.
+ * - `isSingleMode`: Set to `true` to allow only one option to be selected at a time (radio button behavior).
+ * - `colSpan`: The number of columns to span for layout purposes (default is 24 for full width).
+ * - `displayDirection`: The direction to display the options, either "vertical" or "horizontal" (default is "vertical").
+ *
+ * Note: When `isSingleMode` is set to `true`, only one option can be selected at a time, and selecting a new option will automatically deselect the previously selected option.
+ */
+
+const RadioGroup = ({
+  name,
+  title,
+  options,
+  selectedOptions,
+  handleChange,
+  displayDirection = "vertical",
+  isSingleMode = false,
+  colSpan = 24,
+  headColSpan = 15,
+  radioColSpan = 9,
+  tooltip,
+  needUpgrade = false,
+  showProIcon = true,
+  showSingleCheckOverlay = true,
+  children,
+}) => {
+  const itemHandleChange = (option) => {
+    if (isSingleMode) {
+      handleChange(name, option);
+    } else {
+      const updatedOptions = selectedOptions.includes(option)
+        ? selectedOptions.filter((item) => item !== option)
+        : [...selectedOptions, option];
+      handleChange(name, updatedOptions);
+    }
+  };
+
+  const noop = () => {};
+  return (
+    <FieldWrapper
+      colSpan={colSpan}
+      upgradeClass={needUpgrade ? `upgrade-settings` : ""}
+    >
+      <Col span={headColSpan}>
+        <div className={`card-heading radio-input-heading`}>
+          {/* Handle switcher title. */}
+          <Title level={3} className={`settings-heading`}>
+            {title}
+          </Title>
+          {/* Handle switcher tooltip. */}
+          {tooltip && <SettingsTooltip content={tooltip} />}
+          {/* Handle switcher upgrade icon. */}
+          {needUpgrade && <UpgradeCrown />}
+        </div>
+      </Col>
+      <Col span={radioColSpan}>
+        <Space
+          direction={displayDirection}
+          style={{ flexFlow: "wrap" }}
+        >
+          {options.map((radio) => (
+            <label
+              className={`${
+                radio.needUpgrade ? "disabled-checkbox" : "enabled-checkbox"
+              }`}
+              key={radio.value}
+              style={{ display: "flex", gap: "4px" }}
+            >
+              <Radio
+                checked={selectedOptions.includes(radio.value)}
+                onChange={
+                  radio.needUpgrade !== undefined && radio.needUpgrade
+                    ? noop
+                    : () => itemHandleChange(radio.value)
+                }
+                disabled={radio?.disabled || radio?.needUpgrade}
+              >
+                <span style={{ display: "flex", gap: "8px" }}>
+                  {radio.label}
+                  {radio.tooltip === undefined || radio.tooltip === "" ? (
+                    ""
+                  ) : (
+                    <SettingsTooltip content={radio.tooltip} />
+                  )}
+                </span>
+              </Radio>
+              {radio.needUpgrade && showProIcon ? (
+                <UpgradeCrown proBadge={false} />
+              ) : (
+                ""
+              )}
+              {radio.needUpgrade && showSingleCheckOverlay && (
+                <UpgradeOverlay />
+              )}
+            </label>
+          ))}
+        </Space>
+        {children}
+      </Col>
+      {needUpgrade && <UpgradeOverlay />}
+    </FieldWrapper>
+  );
+};
+
+export default RadioGroup;

--- a/modules/direct-checkout/assets/src/components/General.js
+++ b/modules/direct-checkout/assets/src/components/General.js
@@ -7,6 +7,7 @@ import SingleCheckBox from "../../../../../assets/src/components/settings/Panels
 import SettingsSection from "../../../../../assets/src/components/settings/Panels/PanelSettings/SettingsSection";
 import ActionsHandler from "sales-booster/src/components/settings/Panels/PanelSettings/ActionsHandler";
 import { createDirectCheckoutForm } from "../helper";
+import RadioGroup from "sales-booster/src/components/settings/Panels/PanelSettings/Fields/RadioGroup";
 
 function General({ onFormSave, upgradeTeaser }) {
   const { setCreateFromData } = useDispatch("spsg_direct_checkout");
@@ -52,10 +53,10 @@ function General({ onFormSave, upgradeTeaser }) {
   // Define select options.
   let checkoutPageOptions = [
     {
-      label: __("Legacy Checkout", "storegrowth-sales-booster"),
+      label: __("Checkout Page", "storegrowth-sales-booster"),
       value: "legacy-checkout",
       tooltip: __(
-        "The Chekout will redirect to the default checkout page.",
+        "Buy Now button will redirect to the default checkout page",
         "storegrowth-sales-booster"
       ),
     },
@@ -96,15 +97,15 @@ function General({ onFormSave, upgradeTeaser }) {
           createDirectCheckoutFormData
         ) }
 
-        <CheckboxGroup
+        <RadioGroup
           name={"checkout_redirect"}
           options={checkoutPageOptions}
           selectedOptions={createDirectCheckoutFormData.checkout_redirect}
-          handleCheckboxChange={onFieldChange}
+          handleChange={onFieldChange}
           isSingleMode={true}
           title={__("Checkout Redirect", "storegrowth-sales-booster")}
           headColSpan={9}
-          checkboxColSpan={15}
+          radioColSpan={15}
         >
           {/* Rendered direct checkout settings. */}
           { applyFilters(
@@ -112,7 +113,7 @@ function General({ onFormSave, upgradeTeaser }) {
             '',
             isQuickCartActive
           ) }
-        </CheckboxGroup>
+        </RadioGroup>
 
         {/* Rendered sales pop action settings. */}
         { applyFilters(

--- a/modules/direct-checkout/includes/EnqueueScript.php
+++ b/modules/direct-checkout/includes/EnqueueScript.php
@@ -90,8 +90,8 @@ class EnqueueScript implements HookRegistry {
 			$settings_file['version'],
 			false
 		);
-		$spsg_active_module_ids  = \StorePulse\StoreGrowth\Helper::get_settings( 'spsg_active_module_ids' );
-		$is_quick_cart_activated = ! array_key_exists( 'fly-cart', $spsg_active_module_ids );
+		$modules        = storegrowth_get_container()->get( \StorePulse\StoreGrowth\ModuleManager::class );
+		$is_quick_cart_activated = ! $modules->is_active_module('fly-cart');
 		wp_localize_script(
 			'spsg-direct-checkout-settings',
 			'spsgAdminQuickCartValidate',

--- a/modules/fly-cart/assets/src/components/ContentGroup.js
+++ b/modules/fly-cart/assets/src/components/ContentGroup.js
@@ -39,6 +39,7 @@ const ContentGroup = ( {
                 { options && options?.map( ( option, index ) => (
                     <Col
                         span={ 12 }
+                        key={ index }
                         className="gutter-row"
                         style={ {
                             paddingLeft: ( index % 2 === 0 ) ? 0 : 6,


### PR DESCRIPTION
Introduced a new RadioGroup component for settings panels to handle single and multiple option selection. Updated the direct checkout General settings to use RadioGroup instead of CheckboxGroup for checkout redirect options, improving clarity and UX. Also fixed a key warning in ContentGroup and improved module activation check logic in EnqueueScript.php.

## Related Pull Request
* https://github.com/getdokan/storegrowth-sales-booster-pro/pull/184

# Closes
* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced settings selection with a new radio-based control featuring clearer layout, tooltips, and upgrade indicators; supports single or multi-select where applicable.
- Bug Fixes
  - Improved reliability in detecting Quick Cart activation within the admin, ensuring related features behave correctly.
- Documentation
  - Updated label and tooltip text for the Buy Now redirect option to improve clarity (“Checkout Page” and refined tooltip).
- Refactor
  - Streamlined internal activation checks for better consistency.
- Chores
  - Minor UI rendering stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->