### PR TITLE
Fix Frontend initialization order in Dokan

### DIFF
--- a/integrations/includes/Dokan/Dokan.php
+++ b/integrations/includes/Dokan/Dokan.php
@@ -32,8 +32,9 @@ class Dokan implements HookRegistry {
         if ( function_exists( 'dokan_is_seller_dashboard' ) ) {
             Dashboard::instance();
         }
-		Frontend::instance();
+
         Ajax::instance();
+		Frontend::instance();
         Api::instance();
     }
 }

--- a/integrations/includes/Dokan/Dokan.php
+++ b/integrations/includes/Dokan/Dokan.php
@@ -31,9 +31,8 @@ class Dokan implements HookRegistry {
 
         if ( function_exists( 'dokan_is_seller_dashboard' ) ) {
             Dashboard::instance();
-			Frontend::instance();
         }
-
+		Frontend::instance();
         Ajax::instance();
         Api::instance();
     }

--- a/integrations/includes/Dokan/Dokan.php
+++ b/integrations/includes/Dokan/Dokan.php
@@ -31,10 +31,10 @@ class Dokan implements HookRegistry {
 
         if ( function_exists( 'dokan_is_seller_dashboard' ) ) {
             Dashboard::instance();
+			Frontend::instance();
         }
 
         Ajax::instance();
-        Frontend::instance();
         Api::instance();
     }
 }

--- a/integrations/includes/Dokan/Dokan.php
+++ b/integrations/includes/Dokan/Dokan.php
@@ -34,7 +34,7 @@ class Dokan implements HookRegistry {
         }
 
         Ajax::instance();
-		Frontend::instance();
+        Frontend::instance();
         Api::instance();
     }
 }

--- a/integrations/includes/Providers/ServiceProvider.php
+++ b/integrations/includes/Providers/ServiceProvider.php
@@ -28,7 +28,7 @@ class ServiceProvider extends BootableServiceProvider {
      * @return void
      */
     public function boot(): void {
-		if ( function_exists('dokan') ) {
+		if ( function_exists( 'dokan' ) ) {
 			$this->getContainer()->addServiceProvider( new DokanServiceProvider() );
 		}
     }

--- a/integrations/includes/Providers/ServiceProvider.php
+++ b/integrations/includes/Providers/ServiceProvider.php
@@ -28,7 +28,9 @@ class ServiceProvider extends BootableServiceProvider {
      * @return void
      */
     public function boot(): void {
-        $this->getContainer()->addServiceProvider( new DokanServiceProvider() );
+		if ( function_exists('dokan') ) {
+			$this->getContainer()->addServiceProvider( new DokanServiceProvider() );
+		}
     }
 
     /**


### PR DESCRIPTION
Moved Frontend::instance() to ensure it is only initialized when dokan_is_seller_dashboard() exists, aligning with Dashboard initialization.

## Closes

* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system reliability by implementing conditional checks to prevent initialization errors when certain integrations are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->