### PR TITLE
Refactor Ajax calls to use Promises

### DIFF
--- a/assets/src/components/initail-setup/ModulesSetup.jsx
+++ b/assets/src/components/initail-setup/ModulesSetup.jsx
@@ -13,7 +13,7 @@ function ModulesSetup() {
   }));
 
   useEffect(() => {
-    Ajax("get_all_modules").success((response) => {
+    Ajax("get_all_modules").then((response) => {
       updateModules(response);
     });
   }, []);

--- a/assets/src/components/modules/Modules.js
+++ b/assets/src/components/modules/Modules.js
@@ -70,7 +70,7 @@ function Modules() {
 
   useEffect(() => {
     setPageLoading(true);
-    Ajax("get_all_modules").success((response) => {
+    Ajax("get_all_modules").then((response) => {
       // Update to WP data.
       updateModules(response);
       setPageLoading(false);

--- a/assets/src/components/settings/Sidebar.js
+++ b/assets/src/components/settings/Sidebar.js
@@ -48,7 +48,7 @@ function Sidebar({ routes }) {
     };
 
     useEffect(() => {
-        Ajax("get_all_modules").success((response) => {
+        Ajax("get_all_modules").then((response) => {
             const dashboardRoutes = [];
             const availableRoutes = allRoutes.map(availableRoute => availableRoute?.name);
             response?.map(route => {


### PR DESCRIPTION
Replaces usage of .success() with .then() for Ajax calls in ModulesSetup.jsx, Modules.js, and Sidebar.js to standardize promise handling and improve code consistency.

* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal asynchronous request handling across module management components to use modern Promise patterns, replacing legacy callback-based approaches. This improves code consistency and maintainability without affecting user-visible functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->