### PR TITLE
Rename cart error handler method in CartValidator

### DIFF
--- a/modules/upsell-order-bump/includes/Validators/CartValidator.php
+++ b/modules/upsell-order-bump/includes/Validators/CartValidator.php
@@ -12,7 +12,7 @@ class CartValidator implements HookRegistry {
 	public function register_hooks(): void {
 		add_filter( 'woocommerce_cart_item_quantity', [ $this, 'maybe_disable_cart_item_quantity' ], 8, 3 );
 		add_action( 'woocommerce_after_checkout_validation', [ $this, 'after_checkout_validation' ], 10, 2 );
-		add_action( 'woocommerce_store_api_cart_errors', [ $this, 'should_render_validation_error' ] );
+		add_action( 'woocommerce_store_api_cart_errors', [ $this, 'maybe_render_validation_error' ] );
 	}
 
 	/**


### PR DESCRIPTION
Changed the method hooked to 'woocommerce_store_api_cart_errors' from 'should_render_validation_error' to 'maybe_render_validation_error' for consistency and clarity.

* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cart validation error handling to ensure errors are properly displayed during checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->