### PR TITLE
Refactor Ajax calls to use .then instead of .success

### DIFF
--- a/assets/src/components/modules/ModuleCard.js
+++ b/assets/src/components/modules/ModuleCard.js
@@ -13,7 +13,7 @@ function ModuleSwitch({ module }) {
     Ajax( 'update_module_status', {
       module_id: module.id,
       status: checked
-    }).success((response) => {
+    }).then((response) => {
       if (response.success) {
         updateSingleModule(module.id, checked);
         setPageLoading(false);

--- a/assets/src/components/modules/Modules.js
+++ b/assets/src/components/modules/Modules.js
@@ -49,7 +49,7 @@ function Modules() {
     Ajax("update_module_status", {
       module_id: module.id,
       status: true,
-    }).success((response) => {
+    }).then((response) => {
       if (response.success) {
         const spsgSettingsURL = `admin.php?page=spsg-settings#${module.id}`;
         window.location.href = spsgSettingsURL;

--- a/assets/src/components/settings/Sidebar.js
+++ b/assets/src/components/settings/Sidebar.js
@@ -36,7 +36,7 @@ function Sidebar({ routes }) {
         Ajax("update_module_status", {
             module_id: module.name,
             status: true,
-        }).success((response) => {
+        }).then((response) => {
             if (response.success) {
                 // Set active routes for settings panel.
                 setAllRoutes([...allRoutes?.filter(route => route?.name === module?.name || route?.status !== false)]);

--- a/assets/src/utils/helper.js
+++ b/assets/src/utils/helper.js
@@ -151,7 +151,7 @@ export const deactivatorHandler = (moduleID) => {
     Ajax("update_module_status", {
         module_id: moduleID,
         status: false,
-    }).success((response) => {
+    }).then((response) => {
         if (response.success) {
             const spsgSettingsURL = `admin.php?page=spsg-modules`;
             window.location.href = spsgSettingsURL;

--- a/modules/countdown-timer/assets/src/components/SalesCountdownLayout.js
+++ b/modules/countdown-timer/assets/src/components/SalesCountdownLayout.js
@@ -154,7 +154,7 @@ function SalesCountdownLayout({ navigate, useSearchParams, moduleId }) {
         method: "POST",
         data: data,
       })
-      .success(() => {
+      .then(() => {
         setShowUndo(false);
         setButtonLoading(false);
         notificationMessage(type);
@@ -174,7 +174,7 @@ function SalesCountdownLayout({ navigate, useSearchParams, moduleId }) {
           _ajax_nonce: spsgAdmin.nonce,
         },
       })
-      .success((response) => {
+      .then((response) => {
         if (response.success) {
           setFormData({ ...formData, ...response.data });
           setUndoData({ ...undoData, ...response.data });

--- a/modules/floating-notification-bar/assets/src/components/FloatingNotificationBarLayout.js
+++ b/modules/floating-notification-bar/assets/src/components/FloatingNotificationBarLayout.js
@@ -106,7 +106,7 @@ function FloatingNotificationBarLayout({
           _ajax_nonce: spsgAdmin.nonce,
         },
       })
-      .success((response) => {
+      .then((response) => {
         if (response.success && response.data) {
           setFormData({ ...formData, ...response.data });
           setTimeout(() => setPageLoading(false), 500);
@@ -184,7 +184,7 @@ function FloatingNotificationBarLayout({
         method: 'POST',
         data,
       })
-      .success(() => {
+      .then(() => {
         setButtonLoading(false);
         notificationMessage(type);
       });

--- a/modules/fly-cart/assets/src/components/index.js
+++ b/modules/fly-cart/assets/src/components/index.js
@@ -56,7 +56,7 @@ function FlyCart({ navigate, useSearchParams, moduleId }) {
           _ajax_nonce: spsgAdmin.nonce,
         },
       })
-      .success((response) => {
+      .then((response) => {
         if (response.success) {
           updateFormData({ ...formData, ...response.data });
           setTimeout(() => initializeColorPicker(), 10);
@@ -121,7 +121,7 @@ function FlyCart({ navigate, useSearchParams, moduleId }) {
         method: "POST",
         data: data,
       })
-      .success(() => {
+      .then(() => {
         setButtonLoading(false);
         notificationMessage(type);
       });

--- a/modules/progressive-discount-banner/assets/src/components/FreeShippingBarLayout.js
+++ b/modules/progressive-discount-banner/assets/src/components/FreeShippingBarLayout.js
@@ -102,7 +102,7 @@ function FreeShippingBarLayout({
           _ajax_nonce: spsgAdmin.nonce,
         },
       })
-      .success((response) => {
+      .then((response) => {
         if (response.success && response.data) {
           setFormData({ ...formData, ...response.data });
           setUndoData({ ...undoData, ...response.data });
@@ -212,7 +212,7 @@ function FreeShippingBarLayout({
         method: "POST",
         data,
       })
-      .success(() => {
+      .then(() => {
         setShowUndo(false);
         setButtonLoading(false);
         notificationMessage(type);

--- a/modules/quick-view/assets/src/components/QuickViewLayout.jsx
+++ b/modules/quick-view/assets/src/components/QuickViewLayout.jsx
@@ -104,7 +104,7 @@ function QuickViewLayout({ navigate, useSearchParams, moduleId }) {
         method: "POST",
         data: data,
       })
-      .success(() => {
+      .then(() => {
         setButtonLoading(false);
         notificationMessage(type);
       });
@@ -122,7 +122,7 @@ function QuickViewLayout({ navigate, useSearchParams, moduleId }) {
           _ajax_nonce: spsgAdmin?.nonce,
         },
       })
-      .success((response) => {
+      .then((response) => {
         if (response?.success) {
           setFormData({ ...formData, ...response?.data });
           setTimeout(() => setPageLoading(false), 500);

--- a/modules/stock-bar/assets/src/components/StockBarLayout.js
+++ b/modules/stock-bar/assets/src/components/StockBarLayout.js
@@ -83,7 +83,7 @@ function StockBarLayout({ navigate, useSearchParams ,moduleId}) {
         method: "POST",
         data: data,
       })
-      .success(() => {
+      .then(() => {
         setButtonLoading(false);
         notificationMessage(type);
       });
@@ -101,7 +101,7 @@ function StockBarLayout({ navigate, useSearchParams ,moduleId}) {
           _ajax_nonce: spsgAdmin.nonce,
         },
       })
-      .success((response) => {
+      .then((response) => {
         if (response.success) {
           setFormData({ ...formData, ...response.data });
           setTimeout(() => setPageLoading(false), 500);


### PR DESCRIPTION
Replaced deprecated .success() method with .then() for Ajax calls across multiple components to ensure compatibility with modern promise-based APIs and improve code consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal asynchronous handling across multiple components for improved code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->