### PR TITLE
Replace icon with label in BogoOffers actions

### DIFF
--- a/integrations/assets/src/dokan/dashboard/bogo/components/BogoOffers.tsx
+++ b/integrations/assets/src/dokan/dashboard/bogo/components/BogoOffers.tsx
@@ -263,14 +263,13 @@ const BogoOffers = ({ navigate }) => {
   const actions = [
     {
       id: "offer-edit",
-      label: "",
       isPrimary: true,
       isEligible: (item) => !!item.id,
       callback: (offers) => {
         const offer = offers[0];
         navigate(`/bogo/${offer.id}`);
       },
-      icon: () => (
+      label: () => (
         <span
           className={`px-2 bg-transparent font-medium text-dokan-link hover:text-dokan-link-hover pr-r text-sm`}
         >
@@ -280,10 +279,9 @@ const BogoOffers = ({ navigate }) => {
     },
     {
       id: "offer-delete",
-      label: "",
       isPrimary: true,
       isEligible: (item) => !!item.id,
-      icon: () => {
+      label: () => {
         return (
           <span
             className={`px-2 bg-transparent font-medium text-dokan-danger hover:text-dokan-danger-hover text-sm`}


### PR DESCRIPTION
Changed the 'icon' property to 'label' for offer-edit and offer-delete actions in BogoOffers.tsx. This refactor improves clarity and aligns with expected action configuration.

## Closes
* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Replaced icon-only representations with text labels for offer management actions (Edit and Delete) to enhance visibility and improve user experience in the offers dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->