### PR TITLE
fix: Remove unnecessary dokan_is_seller_dashboard check in nav menu

### DIFF
--- a/integrations/includes/Dokan/Dashboard/Bogo.php
+++ b/integrations/includes/Dokan/Dashboard/Bogo.php
@@ -57,9 +57,7 @@ class Bogo {
      * @return array
      */
     public function add_nav_menu( $menus ): array {
-        if ( ! dokan_is_seller_dashboard() ) {
-            return $menus;
-        }
+		// dokan_is_seller_dashboard is checked before this class init
 		$settings = Helper::get_settings( 'spsg_bogo_dokan_vendors_settings', [] );
 
 		if ( isset( $settings['vendors_can_create_buy_x_get_x'] ) && ! $settings['vendors_can_create_buy_x_get_x'] ) {

--- a/integrations/includes/Dokan/Dashboard/Bogo.php
+++ b/integrations/includes/Dokan/Dashboard/Bogo.php
@@ -66,6 +66,7 @@ class Bogo {
         $menus['bogo'] = [
             'title'      => esc_html__( 'BOGO', 'storegrowth-sales-booster' ),
             'icon'       => '<i class="fa-solid fa-box"></i>',
+            'icon_name'  => 'PackagePlus',
             'url'        => dokan_get_navigation_url( '/bogo' ),
             'pos'        => 10,
             'permission' => 'dokandar',


### PR DESCRIPTION
## Closes

* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Bogo" submenu entry with a package-style icon in the seller dashboard navigation.

* **Refactor**
  * Dashboard validation was moved earlier in initialization; behavior for hiding the Bogo option remains governed by vendor settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->