### PR TITLE
fix: correct case of quick view module icon filename

### DIFF
--- a/modules/bogo/includes/Helper.php
+++ b/modules/bogo/includes/Helper.php
@@ -31,9 +31,6 @@ class Helper {
 		$offer_applied_ids                   = wp_list_pluck( $offers, 'offered_products' );
 		$is_variable_product                 = $product->is_type( 'variable' );
 		$offer_available_for_current_product = in_array( $product_id, $offer_applied_ids );
-		error_log ('is_variable_product: ' .  print_r( $is_variable_product, true) );
-		error_log ('product count: ' .  print_r( count( $offers ), true) );
-		error_log ('offer_available_for_current_product: ' .  print_r( $offer_available_for_current_product, true) );
 		// BOGO settings will be available for simple product &
 		return apply_filters(
 			'spsg_load_product_bogo_offer',

--- a/modules/quick-view/includes/QuickViewModule.php
+++ b/modules/quick-view/includes/QuickViewModule.php
@@ -50,7 +50,7 @@ class QuickViewModule extends BaseModule {
 	 * @return string The URL to the module icon.
 	 */
 	public function get_icon(): string {
-		return PluginHelper::get_modules_url( 'quick-view/assets/images/quickview-icon-blue.svg' );
+		return PluginHelper::get_modules_url( 'quick-view/assets/images/quickview-icon-Blue.svg' );
 	}
 
 	/**


### PR DESCRIPTION
* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential quick-view icon display issue on case-sensitive systems.

* **Chores**
  * Removed debug logging statements for improved performance.
  * Applied formatting improvements to codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->