### PR TITLE
Fix misplaced extra quantity button on FlyCart product quantity section

### DIFF
--- a/modules/fly-cart/assets/css/wfc-style.css
+++ b/modules/fly-cart/assets/css/wfc-style.css
@@ -317,6 +317,12 @@
     width: 100px !important;
 }
 
+.spsg-fly-cart-table .product-quantity .quantity .ct-increase, 
+.spsg-fly-cart-table .product-quantity .quantity .ct-decrease {
+    visibility: hidden;
+}
+
+
 .spsg-fly-cart-table .product-quantity button {
     width: 36px;
     background: #fff !important;

--- a/modules/fly-cart/assets/css/wfc-style.css
+++ b/modules/fly-cart/assets/css/wfc-style.css
@@ -319,7 +319,7 @@
 
 .spsg-fly-cart-table .product-quantity .quantity .ct-increase, 
 .spsg-fly-cart-table .product-quantity .quantity .ct-decrease {
-    visibility: hidden;
+    display: none;
 }
 
 


### PR DESCRIPTION
*  Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quantity increment and decrement controls are now hidden in the fly cart table display.
  * Visual styling elsewhere in the fly cart remains unchanged; no other UI elements or behaviors were modified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->