### PR TITLE
fix: Typo in Module Activation

### DIFF
--- a/assets/src/components/modules/ActivationAlert.js
+++ b/assets/src/components/modules/ActivationAlert.js
@@ -32,12 +32,12 @@ const ActivationAlert = ({
             />
           </div>
           <h3 className="modal-content-heading">
-            {`Do you want to active ${ isDashboard ? activeModalData?.label : activeModalData?.name }?`}
+            {`Do you want to activate ${ isDashboard ? activeModalData?.label : activeModalData?.name }?`}
           </h3>
           <p className="modal-content">
             After activating the <strong>{ isDashboard ? activeModalData?.label : activeModalData?.name }</strong>{" "}
             module, you will be redirected to the module settings page where you
-            can set up this module's features..
+            can set up this module's features.
           </p>
           <div className="modal-controller-action-button">
             <Button


### PR DESCRIPTION
Fixed the typo of "active" and double full-stop at the end in the Module Activation Popup

* Closes https://github.com/getdokan/plugin-internal-tasks/issues/1293
* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed textual content and punctuation in activation alert dialog for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->