### PR TITLE
Fix fatal error when order bump product is missing or deleted

### DIFF
--- a/modules/upsell-order-bump/includes/Blocks/OrderBumpCheckoutIntegration.php
+++ b/modules/upsell-order-bump/includes/Blocks/OrderBumpCheckoutIntegration.php
@@ -94,7 +94,11 @@ class OrderBumpCheckoutIntegration implements IntegrationInterface {
 				$checked = 'checked';
 			}
 
-			$_product      = wc_get_product( $offer_product_id );
+			$_product = wc_get_product( $offer_product_id );
+			if ( ! $_product || ! $_product->is_purchasable() ) {
+				continue;
+			}
+
 			$regular_price = $_product->get_regular_price();
 			// Use sale price if available, otherwise use regular price for discount calculation
 			$current_price = $_product->get_sale_price() ? $_product->get_sale_price() : $regular_price;


### PR DESCRIPTION
### Closes 

* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Order bump offers now include proper validation checks for product availability and purchasability before display. Products marked as unavailable or non-purchasable are automatically skipped from the offer sequence during checkout. This prevents customers from encountering invalid offers and ensures a smoother, more reliable checkout experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->