### PR TITLE
fix: update ajax_url to use admin_url function for better compatibility

### DIFF
--- a/modules/direct-checkout/includes/EnqueueScript.php
+++ b/modules/direct-checkout/includes/EnqueueScript.php
@@ -66,7 +66,7 @@ class EnqueueScript implements HookRegistry {
 			array(
 				'isQuickCartCheckout' => $is_checkout_redirect,
 				'isPro'               => sp_store_growth()->has_pro(),
-				'ajax_url'            => '/wp-admin/admin-ajax.php',
+				'ajax_url'            => admin_url( 'admin-ajax.php' ),
 			)
 		);
 	}


### PR DESCRIPTION
## Summary

* Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/218

- Update Direct Checkout AJAX URL to use `admin_url( 'admin-ajax.php' )` instead of a hardcoded value for improved compatibility.

## Changelog

- **Fixed**: Direct Checkout AJAX endpoint now uses `admin_url( 'admin-ajax.php' )` to generate `ajax_url`, ensuring it respects custom admin paths, reverse proxies, and non-standard setups.

## Technical details

- Updated `modules/direct-checkout/includes/EnqueueScript.php` to build the AJAX URL via `admin_url( 'admin-ajax.php' )` when localizing script data.

## Testing

- Enable Direct Checkout module.
- Trigger an AJAX request that previously used the direct checkout AJAX URL (e.g., add to cart / checkout flow).
- Verify requests hit the correct `admin-ajax.php` endpoint.
- Confirm no 404s or mixed-content issues on non-standard admin URLs (custom admin path, HTTPS offload, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal path handling to use WordPress standard practices for better reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->