### PR TITLE
fix: scope BOGO duplicate check to active global offers only

### DIFF
--- a/modules/bogo/includes/REST/BogoController.php
+++ b/modules/bogo/includes/REST/BogoController.php
@@ -310,9 +310,11 @@ class BogoController extends WP_REST_Controller {
         // Prepare data for creation (can be customized by child classes)
         $data = $this->prepare_data_for_creation( $data, $request );
 
-		// check the duplicate bogo offer
+		// check the duplicate bogo offer among active global offers only
 		$existing = BogoDataManager::get_bogo_offers([
 			'offered_products' => wp_json_encode( $data['offered_products'] ?? array() ),
+			'type'             => 'global',
+			'status'           => 'active',
 		]);
 
 		if ( ! empty( $existing ) ) {


### PR DESCRIPTION
## Summary
- Fixed false "product already has an active BOGO offer" error when adding variable products as targets
- Scoped the duplicate offer check to only query active global offers, excluding product-level and inactive records

* Closes: https://github.com/getdokan/storegrowth-sales-booster-pro/issues/215

## Test plan
- [ ] Create a BOGO offer with a variable product as the target — should succeed without error
- [ ] Verify that creating a truly duplicate active global offer is still blocked
- [ ] Verify that deactivating an existing offer allows creating a new one with the same products

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved BOGO offer duplicate detection to only validate against active global offers, providing more accurate results when creating new promotions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->