### PR TITLE
fix: prevent same product selection in Buy X Get Y BOGO deal

### DIFF
--- a/modules/bogo/assets/src/components/CreateBogo.jsx
+++ b/modules/bogo/assets/src/components/CreateBogo.jsx
@@ -45,7 +45,7 @@ function CreateBogo({ navigate, useParams, useSearchParams }) {
           setPageLoading(false);
           console.error('Failed to fetch BOGO offers:', error);
           notification["error"]({
-            message: "Failed to load BOGO offers",
+            message: __("Failed to load BOGO offers", "storegrowth-sales-booster"),
             description: error.message,
           });
         });
@@ -111,7 +111,7 @@ function CreateBogo({ navigate, useParams, useSearchParams }) {
           setPageLoading(false);
           console.error('Failed to fetch BOGO offer:', error);
           notification["error"]({
-            message: "Failed to load BOGO offer",
+            message: __("Failed to load BOGO offer", "storegrowth-sales-booster"),
             description: error.message,
           });
         });
@@ -134,7 +134,7 @@ function CreateBogo({ navigate, useParams, useSearchParams }) {
   const onFormSave = () => {
     if (!createBogoData.name_of_order_bogo) {
       notification["error"]({
-        message: "Please enter name of order bogo",
+        message: __("Please enter name of order bogo", "storegrowth-sales-booster"),
       });
       return null;
     }
@@ -144,8 +144,10 @@ function CreateBogo({ navigate, useParams, useSearchParams }) {
       createBogoData.offered_categories.length === 0
     ) {
       notification["error"]({
-        message:
+        message: __(
           "You have to select target products or target categories or both",
+          "storegrowth-sales-booster"
+        ),
       });
 
       return null;
@@ -153,7 +155,7 @@ function CreateBogo({ navigate, useParams, useSearchParams }) {
 
     if (createBogoData.offer_schedule.length === 0) {
       notification["error"]({
-        message: "Please select bogo schedule",
+        message: __("Please select bogo schedule", "storegrowth-sales-booster"),
       });
 
       return null;
@@ -161,7 +163,7 @@ function CreateBogo({ navigate, useParams, useSearchParams }) {
 
     if (!createBogoData.get_different_product_field && createBogoData.bogo_deal_type !== 'same') {
       notification["error"]({
-        message: "Please select offer product",
+        message: __("Please select offer product", "storegrowth-sales-booster"),
       });
 
       return null;
@@ -173,7 +175,10 @@ function CreateBogo({ navigate, useParams, useSearchParams }) {
       createBogoData.offered_products.map(Number).includes(Number(createBogoData.get_different_product_field))
     ) {
       notification["error"]({
-        message: "Offer product cannot be the same as a target product. Use 'Buy X Get X' deal type for same product offers.",
+        message: __(
+          "Offer product cannot be the same as a target product. Use 'Buy X Get X' deal type for same product offers.",
+          "storegrowth-sales-booster"
+        ),
       });
 
       return null;
@@ -181,7 +186,7 @@ function CreateBogo({ navigate, useParams, useSearchParams }) {
 
     if (!createBogoData.offer_type || createBogoData.offer_type.length === 0) {
       notification["error"]({
-        message: "Please select offer type",
+        message: __("Please select offer type", "storegrowth-sales-booster"),
       });
 
       return null;
@@ -189,7 +194,7 @@ function CreateBogo({ navigate, useParams, useSearchParams }) {
 
     if (createBogoData.offer_type !== "free" && !createBogoData.discount_amount) {
       notification["error"]({
-        message: "Please select offer amount",
+        message: __("Please select offer amount", "storegrowth-sales-booster"),
       });
 
       return null;

--- a/modules/bogo/assets/src/components/CreateBogo.jsx
+++ b/modules/bogo/assets/src/components/CreateBogo.jsx
@@ -167,6 +167,18 @@ function CreateBogo({ navigate, useParams, useSearchParams }) {
       return null;
     }
 
+    if (
+      createBogoData.bogo_deal_type !== 'same' &&
+      createBogoData.get_different_product_field &&
+      createBogoData.offered_products.map(Number).includes(Number(createBogoData.get_different_product_field))
+    ) {
+      notification["error"]({
+        message: "Offer product cannot be the same as a target product. Use 'Buy X Get X' deal type for same product offers.",
+      });
+
+      return null;
+    }
+
     if (!createBogoData.offer_type || createBogoData.offer_type.length === 0) {
       notification["error"]({
         message: "Please select offer type",

--- a/modules/bogo/includes/BogoValidator.php
+++ b/modules/bogo/includes/BogoValidator.php
@@ -246,12 +246,12 @@ class BogoValidator {
 
 		// Check required fields
 		if ( empty( $bogo_settings['status'] ) ) {
-			$errors[] = 'BOGO status is required';
+			$errors[] = __( 'BOGO status is required', 'storegrowth-sales-booster' );
 			$valid = false;
 		}
 
 		if ( empty( $bogo_settings['bogo_deal_type'] ) ) {
-			$errors[] = 'BOGO deal type is required';
+			$errors[] = __( 'BOGO deal type is required', 'storegrowth-sales-booster' );
 			$valid = false;
 		}
 
@@ -260,10 +260,10 @@ class BogoValidator {
 		if ( 'product' === $type ) {
 			if ( empty( $bogo_settings['product_id'] ) ) {
 				if ( $strict_mode ) {
-					$errors[] = 'Product ID is required for product type BOGO';
+					$errors[] = __( 'Product ID is required for product type BOGO', 'storegrowth-sales-booster' );
 					$valid = false;
 				} else {
-					$warnings[] = 'Product ID is empty for product type BOGO';
+					$warnings[] = __( 'Product ID is empty for product type BOGO', 'storegrowth-sales-booster' );
 				}
 			}
 		} elseif ( 'global' === $type ) {
@@ -273,10 +273,10 @@ class BogoValidator {
 			
 			if ( ! $has_products && ! $has_categories ) {
 				if ( $strict_mode ) {
-					$errors[] = 'Global BOGO must specify either offered products or categories';
+					$errors[] = __( 'Global BOGO must specify either offered products or categories', 'storegrowth-sales-booster' );
 					$valid = false;
 				} else {
-					$warnings[] = 'Global BOGO has no offered products or categories specified';
+					$warnings[] = __( 'Global BOGO has no offered products or categories specified', 'storegrowth-sales-booster' );
 				}
 			}
 		}
@@ -285,18 +285,18 @@ class BogoValidator {
 		if ( isset( $bogo_settings['bogo_deal_type'] ) && 'different' === $bogo_settings['bogo_deal_type'] ) {
 			$offer_product_id = self::get_offer_product_id( $bogo_settings, 0 );
 			if ( ! $offer_product_id ) {
-				$errors[] = 'Offer product ID is required for different deal type';
+				$errors[] = __( 'Offer product ID is required for different deal type', 'storegrowth-sales-booster' );
 				$valid = false;
 			} else {
 				// Prevent selecting the same product as both target and offer (that would be Buy X Get X)
 				$offered_products = $bogo_settings['offered_products'] ?? array();
 				if ( is_array( $offered_products ) && in_array( (int) $offer_product_id, array_map( 'intval', $offered_products ), true ) ) {
-					$errors[] = 'Offer product cannot be the same as a target product in Buy X Get Y deal';
+					$errors[] = __( 'Offer product cannot be the same as a target product in Buy X Get Y deal', 'storegrowth-sales-booster' );
 					$valid = false;
 				}
 				// For product-type BOGO, also check against the product itself
 				if ( ! empty( $bogo_settings['product_id'] ) && (int) $offer_product_id === (int) $bogo_settings['product_id'] ) {
-					$errors[] = 'Offer product cannot be the same as the target product in Buy X Get Y deal';
+					$errors[] = __( 'Offer product cannot be the same as the target product in Buy X Get Y deal', 'storegrowth-sales-booster' );
 					$valid = false;
 				}
 			}
@@ -306,7 +306,7 @@ class BogoValidator {
 		if ( isset( $bogo_settings['offer_type'] ) && 'discount' === $bogo_settings['offer_type'] ) {
 			$discount_amount = floatval( $bogo_settings['discount_amount'] ?? 0 );
 			if ( $discount_amount <= 0 || $discount_amount > 100 ) {
-				$errors[] = 'Discount amount must be between 1 and 100';
+				$errors[] = __( 'Discount amount must be between 1 and 100', 'storegrowth-sales-booster' );
 				$valid = false;
 			}
 		}
@@ -317,44 +317,48 @@ class BogoValidator {
 
 		// Check for invalid date formats
 		if ( ! empty( $offer_start ) && '0000-00-00' === $offer_start ) {
-			$warnings[] = 'Offer start date has invalid format (0000-00-00)';
+			$warnings[] = __( 'Offer start date has invalid format (0000-00-00)', 'storegrowth-sales-booster' );
 			$offer_start = null; // Treat as empty
 		}
 
 		if ( ! empty( $offer_end ) && '0000-00-00' === $offer_end ) {
-			$warnings[] = 'Offer end date has invalid format (0000-00-00)';
+			$warnings[] = __( 'Offer end date has invalid format (0000-00-00)', 'storegrowth-sales-booster' );
 			$offer_end = null; // Treat as empty
 		}
 
 		// Validate date range
 		if ( ! empty( $offer_start ) && ! empty( $offer_end ) ) {
 			if ( $offer_start > $offer_end ) {
-				$errors[] = 'Offer start date must be before end date';
+				$errors[] = __( 'Offer start date must be before end date', 'storegrowth-sales-booster' );
 				$valid = false;
 			}
 		}
 
 		// Check for empty display messages (warnings only)
 		if ( empty( $bogo_settings['product_page_message'] ) && empty( $bogo_settings['shop_page_message'] ) ) {
-			$warnings[] = 'No display messages specified - users may not see BOGO offer information';
+			$warnings[] = __( 'No display messages specified - users may not see BOGO offer information', 'storegrowth-sales-booster' );
 		}
 
 		// Check for empty badge image
 		if ( empty( $bogo_settings['bogo_badge_image'] ) ) {
-			$warnings[] = 'No badge image specified - offer may not be visually prominent';
+			$warnings[] = __( 'No badge image specified - offer may not be visually prominent', 'storegrowth-sales-booster' );
 		}
 
 		// Validate minimum quantity
 		$min_qty = intval( $bogo_settings['minimum_quantity_required'] ?? 1 );
 		if ( $min_qty < 1 ) {
-			$errors[] = 'Minimum quantity required must be at least 1';
+			$errors[] = __( 'Minimum quantity required must be at least 1', 'storegrowth-sales-booster' );
 			$valid = false;
 		}
 
 		// Validate status field
 		$status = $bogo_settings['status'] ?? 'active';
 		if ( ! in_array( $status, array( 'active', 'inactive' ), true ) ) {
-			$warnings[] = 'Invalid status value: ' . $status . ' (should be active or inactive)';
+			$warnings[] = sprintf(
+				/* translators: %s: the invalid status value */
+				__( 'Invalid status value: %s (should be active or inactive)', 'storegrowth-sales-booster' ),
+				$status
+			);
 		}
 
 		return array(

--- a/modules/bogo/includes/BogoValidator.php
+++ b/modules/bogo/includes/BogoValidator.php
@@ -287,6 +287,18 @@ class BogoValidator {
 			if ( ! $offer_product_id ) {
 				$errors[] = 'Offer product ID is required for different deal type';
 				$valid = false;
+			} else {
+				// Prevent selecting the same product as both target and offer (that would be Buy X Get X)
+				$offered_products = $bogo_settings['offered_products'] ?? array();
+				if ( is_array( $offered_products ) && in_array( (int) $offer_product_id, array_map( 'intval', $offered_products ), true ) ) {
+					$errors[] = 'Offer product cannot be the same as a target product in Buy X Get Y deal';
+					$valid = false;
+				}
+				// For product-type BOGO, also check against the product itself
+				if ( ! empty( $bogo_settings['product_id'] ) && (int) $offer_product_id === (int) $bogo_settings['product_id'] ) {
+					$errors[] = 'Offer product cannot be the same as the target product in Buy X Get Y deal';
+					$valid = false;
+				}
 			}
 		}
 


### PR DESCRIPTION
Closes: https://github.com/getdokan/storegrowth-sales-booster-pro/issues/232


In Buy X Get Y deals, users could select the same product as both the target and offer product, effectively replicating the pro-only Buy X Get X behaviour without the upgrade.

- Add frontend validation in CreateBogo.jsx to block saving when the offer product matches any selected target product
- Add backend validation in BogoValidator.php for both global (offered_products) and product-type BOGOs to enforce the same rule server-side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents saving BOGO deals when an offer product conflicts with selected target products for "different" deals; shows an error notification and blocks save to ensure deal integrity.
* **Localization**
  * Error and notification messages (validation errors and offer load failures) are now localized for translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->