### PR TITLE
Fix incorrect text domains in translation functions

### DIFF
--- a/assets/src/components/initail-setup/Ready.jsx
+++ b/assets/src/components/initail-setup/Ready.jsx
@@ -9,7 +9,7 @@ const Ready = () => {
         <div className='ini-setup-announce-container congratulation'>
           <img className='annouce-image' src={CongratsAnnounce} alt="storegrowth-icon" />
           <div className='annouce-contents'>
-            <h3 className='spsg-content-heading'>{__("Congratulation!", "storegrowth-sales-booster")}</h3>
+            <h3 className='spsg-content-heading'>{__("Congratulations!", "storegrowth-sales-booster")}</h3>
             <span className='spsg-sub-heading'>{__(`You are at the last step to complete the setup process and start using the exciting features of StoreGrowth`, 'storegrowth-sales-booster')}</span>
           </div>
           <div className="social-links">

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -192,7 +192,7 @@ class Ajax {
 			 */
 			$plugin = $this->plugin_data();
 		if ( empty( $plugin ) ) {
-			$body['message'] .= __( 'We can\'t detect any plugin information. This is most probably because you have not included the code in the plugin main file.', 'plugin-usage-tracker' );
+			$body['message'] .= __( 'We can\'t detect any plugin information. This is most probably because you have not included the code in the plugin main file.', 'storegrowth-sales-booster' );
 			$body['status']   = 'NOT FOUND';
 		} else {
 			if ( isset( $plugin['Name'] ) ) {

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -192,7 +192,7 @@ class Ajax {
 			 */
 			$plugin = $this->plugin_data();
 		if ( empty( $plugin ) ) {
-			$body['message'] .= __( 'We can\'t detect any plugin information. This is most probably because you have not included the code in the plugin main file.', 'storegrowth-sales-booster' );
+			$body['message'] = ( $body['message'] ?? '' ) . __( 'We can\'t detect any plugin information. This is most probably because you have not included the code in the plugin main file.', 'storegrowth-sales-booster' );
 			$body['status']   = 'NOT FOUND';
 		} else {
 			if ( isset( $plugin['Name'] ) ) {

--- a/modules/bogo/assets/src/components/BasicInfo.jsx
+++ b/modules/bogo/assets/src/components/BasicInfo.jsx
@@ -30,8 +30,8 @@ const BasicInfo = ({ clearErrors }) => {
   const [productListForSelect, setProductListForSelect] = useState([]);
 
   const offerOptions = [
-    { value: "free", label: __("Free", "storegrowth-sales-booster-pro") },
-    { value: "discount", label: __("Discount%", "storegrowth-sales-booster-pro") },
+    { value: "free", label: __("Free", "storegrowth-sales-booster") },
+    { value: "discount", label: __("Discount%", "storegrowth-sales-booster") },
   ];
 
   const handleProductSelection = (key, value, infoKey, item) => {
@@ -52,7 +52,7 @@ const BasicInfo = ({ clearErrors }) => {
         return notification["error"]({
           message: __(
             "Discount offer can't be greater than 100 percent!",
-            "storegrowth-sales-booster-pro"
+            "storegrowth-sales-booster"
           ),
         });
       }
@@ -64,7 +64,7 @@ const BasicInfo = ({ clearErrors }) => {
       createBogoData?.offered_products.length === 0 // Check if no target products are selected
     ) {
       return notification["error"]({
-        message: __("Please select target products first", "storegrowth-sales-booster-pro"),
+        message: __("Please select target products first", "storegrowth-sales-booster"),
       });
     }
 
@@ -94,10 +94,10 @@ const BasicInfo = ({ clearErrors }) => {
           name={`name_of_order_bogo`}
           changeHandler={onFieldChange}
           fieldValue={createBogoData.name_of_order_bogo}
-          title={__("Name of BOGO", "storegrowth-sales-booster-pro")}
+          title={__("Name of BOGO", "storegrowth-sales-booster")}
           placeHolderText={__(
             "Enter BOGO Name",
-            "storegrowth-sales-booster-pro"
+            "storegrowth-sales-booster"
           )}
         />
         <ProductAsyncSelect
@@ -105,11 +105,11 @@ const BasicInfo = ({ clearErrors }) => {
           name="offered_products"
           changeHandler={(key, value, item) => handleProductSelection(key, value, 'get_offered_product_info', item)}
           fieldValue={ createBogoData?.get_offered_product_info?.name }
-          title={__("Select Target Product(s)", "storegrowth-sales-booster-pro")}
-          placeHolderText={__("Search for products", "storegrowth-sales-booster-pro")}
+          title={__("Select Target Product(s)", "storegrowth-sales-booster")}
+          placeHolderText={__("Search for products", "storegrowth-sales-booster")}
           tooltip={__(
             "The target product indicates for which specific products the upsell order bogo option will be displayed.",
-            "storegrowth-sales-booster-pro"
+            "storegrowth-sales-booster"
           )}
         />
 
@@ -128,14 +128,14 @@ const BasicInfo = ({ clearErrors }) => {
             fieldWidth={"100%"}
             name={`get_different_product_field`}
             changeHandler={(key, value, item) => handleProductSelection(key, value, 'get_different_product_info', item)}
-            title={__("Offer Product", "storegrowth-sales-booster-pro")}
+            title={__("Offer Product", "storegrowth-sales-booster")}
             tooltip={__(
               "The specific product that will be available in the order bogo with an offer.",
-              "storegrowth-sales-booster-pro"
+              "storegrowth-sales-booster"
             )}
             placeHolderText={__(
               "Search for offer product",
-              "storegrowth-sales-booster-pro"
+              "storegrowth-sales-booster"
             )}
             fieldValue={ createBogoData?.get_different_product_info?.name }
             filterOption={(inputValue, option) =>
@@ -165,9 +165,9 @@ const BasicInfo = ({ clearErrors }) => {
        {DISPLAY_FIELDS.bogoType && (
         <TextRadioBox
           name={`bogo_type`}
-          title={__("Select BOGO Type", "storegrowth-sales-booster-pro")}
+          title={__("Select BOGO Type", "storegrowth-sales-booster")}
           classes={""}
-          tooltip={__("this is an example", "storegrowth-sales-booster-pro")}
+          tooltip={__("this is an example", "storegrowth-sales-booster")}
           options={[...dealCategories]}
           fieldValue={createBogoData?.bogo_type}
           changeHandler={onFieldChange}
@@ -181,11 +181,11 @@ const BasicInfo = ({ clearErrors }) => {
                 changeHandler={onFieldChange}
                 options={productListForSelect}
                 fieldValue={createBogoData?.get_alternate_products ? createBogoData?.get_alternate_products.map(Number) : []}
-                title={__("Alternate option of the offered products", "storegrowth-sales-booster-pro")}
-                placeHolderText={__("Search for products", "storegrowth-sales-booster-pro")}
+                title={__("Alternate option of the offered products", "storegrowth-sales-booster")}
+                placeHolderText={__("Search for products", "storegrowth-sales-booster")}
                 tooltip={__(
                   "The target product indicates for which specific products the upsell order bogo option will be displayed.",
-                  "storegrowth-sales-booster-pro"
+                  "storegrowth-sales-booster"
                 )}
               />
             ) : (
@@ -195,11 +195,11 @@ const BasicInfo = ({ clearErrors }) => {
                   changeHandler={onFieldChange}
                   fieldValue={createBogoData?.get_alternate_categories ? createBogoData?.get_alternate_categories.map(Number) : []}
                   options={bogo_products_and_categories?.category_list?.catForSelect}
-                  title={__("Offer this category product as alternate product for this offer", "storegrowth-sales-booster-pro")}
-                  placeHolderText={__("Search for Categories", "storegrowth-sales-booster-pro")}
+                  title={__("Offer this category product as alternate product for this offer", "storegrowth-sales-booster")}
+                  placeHolderText={__("Search for Categories", "storegrowth-sales-booster")}
                   tooltip={__(
                     "The target categories indicate for which specific categories the upsell order bogo option will be displayed.",
-                    "storegrowth-sales-booster-pro"
+                    "storegrowth-sales-booster"
                   )}
                 />
               </Fragment>

--- a/modules/bogo/includes/REST/BogoController.php
+++ b/modules/bogo/includes/REST/BogoController.php
@@ -318,7 +318,7 @@ class BogoController extends WP_REST_Controller {
 		if ( ! empty( $existing ) ) {
 			return new WP_Error(
 				'bogo_offer_exists',
-				__('This product already has an active BOGO offer. Please remove the previous offer or select different products to create a new one.', '')
+				__('This product already has an active BOGO offer. Please remove the previous offer or select different products to create a new one.', 'storegrowth-sales-booster')
 			);
 		}
 

--- a/modules/fly-cart/assets/src/components/DesignSettings.js
+++ b/modules/fly-cart/assets/src/components/DesignSettings.js
@@ -124,7 +124,7 @@ const DesignSettings = ({
                 name={ `product_card_bg_color` }
                 changeHandler={ onFieldChange }
                 fieldValue={ formData.product_card_bg_color }
-                title={ __( 'Product Card Backgorund Color', 'storegrowth-sales-booster' ) }
+                title={ __( 'Product Card Background Color', 'storegrowth-sales-booster' ) }
             />
             <ActionsHandler
                 saveHandler={ onFormSave }

--- a/modules/quick-view/assets/src/components/DesingTab.jsx
+++ b/modules/quick-view/assets/src/components/DesingTab.jsx
@@ -52,7 +52,7 @@ function DesignTab(props) {
           name={"modal_background_color"}
           fieldValue={formData?.modal_background_color}
           changeHandler={onFieldChange}
-          title={__("Modal Backgroud Color", "storegrowth-sales-booster")}
+          title={__("Modal Background Color", "storegrowth-sales-booster")}
         />
 
         {applyFilters(

--- a/modules/quick-view/templates/description-template.php
+++ b/modules/quick-view/templates/description-template.php
@@ -1,6 +1,6 @@
 <?php 
 global $post;
-$heading = apply_filters( 'spsg_product_description_heading', __( 'Description', 'woocommerce' ) );
+$heading = apply_filters( 'spsg_product_description_heading', __( 'Description', 'storegrowth-sales-booster' ) );
 ?>
 
 <?php if ( $heading ) : ?>

--- a/modules/quick-view/templates/description-template.php
+++ b/modules/quick-view/templates/description-template.php
@@ -1,6 +1,6 @@
 <?php 
 global $post;
-$heading = apply_filters( 'spsg_product_description_heading', __( 'Description', 'storegrowth-sales-booster' ) );
+$heading = apply_filters( 'spsg_product_description_heading', __( 'Description', 'woocommerce' ) );
 ?>
 
 <?php if ( $heading ) : ?>


### PR DESCRIPTION
closes: https://github.com/getdokan/storegrowth-sales-booster-pro/issues/231
Related PR: https://github.com/getdokan/storegrowth-sales-booster-pro/pull/230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified translation text domain across the plugin for more consistent localization.

* **Bug Fixes**
  * Fixed several user-facing typos and wording ("Congratulation!" → "Congratulations!", "Backgorund"/"Backgroud" → "Background").

* **Minor**
  * Small UI/state housekeeping with no visible behavioral change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->