### PR TITLE
fix: separate admin nonce from frontend nonce for popup ajax (pro#240)

### DIFF
--- a/modules/bogo/includes/Ajax.php
+++ b/modules/bogo/includes/Ajax.php
@@ -46,7 +46,7 @@ class Ajax implements HookRegistry {
 	}
 
 	public function handle_update_offer_product() {
-		check_ajax_referer( 'ajd_protected' );
+		check_ajax_referer( 'spsg_frontend_protected' );
 
 		$data = ! empty( $_POST['data'] ) ? wc_clean( $_POST['data'] ) : array();
 		if ( empty( $data ) ) {
@@ -253,7 +253,7 @@ class Ajax implements HookRegistry {
 	 * Bogo product add to cart.
 	 */
 	public function offer_product_add_to_cart() {
-		check_ajax_referer( 'ajd_protected' );
+		check_ajax_referer( 'spsg_frontend_protected' );
 
 		global $woocommerce;
 		$all_cart_products = $woocommerce->cart->get_cart();

--- a/modules/bogo/includes/Ajax.php
+++ b/modules/bogo/includes/Ajax.php
@@ -199,7 +199,7 @@ class Ajax implements HookRegistry {
      * Bogo category message creation.
      */
     public function bogo_category_msg_create() {
-        check_ajax_referer( 'ajd_protected' );
+		check_ajax_referer( 'spsg_admin_protected' );
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
@@ -230,7 +230,7 @@ class Ajax implements HookRegistry {
      * Bogo category message list.
      */
     public function bogo_category_msg_list() {
-        check_ajax_referer( 'ajd_protected' );
+		check_ajax_referer( 'spsg_admin_protected' );
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );

--- a/modules/bogo/includes/EnqueueScript.php
+++ b/modules/bogo/includes/EnqueueScript.php
@@ -92,8 +92,8 @@ class EnqueueScript implements HookRegistry {
 			);
 
 			// Admin-only nonce for privileged option-writing ajax (create/list
-			// category messages). Kept distinct from the frontend `ajd_protected`
-			// nonce so a scraped storefront nonce can't authorize admin actions.
+			// category messages). Kept distinct from the frontend cart nonce so a
+			// scraped storefront nonce can't authorize admin actions.
 			$action    = 'spsg_admin_protected';
 			$ajd_nonce = wp_create_nonce( $action );
 
@@ -170,7 +170,10 @@ class EnqueueScript implements HookRegistry {
 			true
 		);
 
-		$action    = 'ajd_protected';
+		// Frontend-only nonce for the public storefront cart actions
+		// (add/update BOGO gift). Deliberately NOT the admin nonce — a scraped
+		// storefront nonce must never authorize a settings write.
+		$action    = 'spsg_frontend_protected';
 		$ajd_nonce = wp_create_nonce( $action );
 		wp_localize_script(
 			'spsg-bogo-front-js',

--- a/modules/bogo/includes/EnqueueScript.php
+++ b/modules/bogo/includes/EnqueueScript.php
@@ -91,7 +91,10 @@ class EnqueueScript implements HookRegistry {
 				true
 			);
 
-			$action    = 'ajd_protected';
+			// Admin-only nonce for privileged option-writing ajax (create/list
+			// category messages). Kept distinct from the frontend `ajd_protected`
+			// nonce so a scraped storefront nonce can't authorize admin actions.
+			$action    = 'spsg_admin_protected';
 			$ajd_nonce = wp_create_nonce( $action );
 
 			wp_localize_script(

--- a/modules/sales-pop/includes/Ajax.php
+++ b/modules/sales-pop/includes/Ajax.php
@@ -39,7 +39,7 @@ class Ajax implements HookRegistry {
 	 * unauthenticated visitors.
 	 */
 	public function popup_products() {
-		check_ajax_referer( 'ajd_protected' );
+		check_ajax_referer( 'spsg_admin_protected' );
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
@@ -55,7 +55,7 @@ class Ajax implements HookRegistry {
 	 * fields that are later rendered on the storefront.
 	 */
 	public function create_popup() {
-		check_ajax_referer( 'ajd_protected' );
+		check_ajax_referer( 'spsg_admin_protected' );
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );

--- a/modules/sales-pop/includes/EnqueueScript.php
+++ b/modules/sales-pop/includes/EnqueueScript.php
@@ -154,7 +154,7 @@ class EnqueueScript implements HookRegistry {
 				'sales_pop_data',
 				array(
 					'ajax_url'     => admin_url( 'admin-ajax.php' ),
-					'ajd_nonce'    => wp_create_nonce( 'ajd_protected' ),
+					'ajd_nonce'    => wp_create_nonce( 'spsg_admin_protected' ),
 					'image_folder' => PluginHelper::get_modules_url( 'upsell-order-bump/assets/images' ),
 					'product_list' => $this->product_list(),
 				)

--- a/modules/upsell-order-bump/includes/EnqueueScript.php
+++ b/modules/upsell-order-bump/includes/EnqueueScript.php
@@ -58,7 +58,8 @@ class EnqueueScript implements HookRegistry {
 				true
 			);
 
-			$action    = 'ajd_protected';
+			// Admin-only nonce (settings screen). Distinct from the frontend cart nonce.
+			$action    = 'spsg_admin_protected';
 			$ajd_nonce = wp_create_nonce( $action );
 
 			wp_localize_script(
@@ -138,7 +139,8 @@ class EnqueueScript implements HookRegistry {
 			true
 		);
 
-		$action    = 'ajd_protected';
+		// Frontend-only nonce for the public order-bump add-to-cart action.
+		$action    = 'spsg_frontend_protected';
 		$ajd_nonce = wp_create_nonce( $action );
 		wp_localize_script(
 			'spsg-order-bump-front-js',

--- a/modules/upsell-order-bump/includes/OrderBumpAjax.php
+++ b/modules/upsell-order-bump/includes/OrderBumpAjax.php
@@ -31,7 +31,7 @@ class OrderBumpAjax implements HookRegistry {
 	 * Bump product add to cart.
 	 */
 	public function upsell_offer_product_add_to_cart() {
-		check_ajax_referer( 'ajd_protected' );
+		check_ajax_referer( 'spsg_frontend_protected' );
 		
 		global $woocommerce;
 		$all_cart_products = $woocommerce->cart->get_cart();

--- a/tests/e2e/tests/api/bogo-category-msg-auth.api.spec.ts
+++ b/tests/e2e/tests/api/bogo-category-msg-auth.api.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '../../fixtures/test';
+import { env } from '../../helpers/env';
+
+/**
+ * Regression for CVE-2026-13110 — unauthenticated settings modification via the
+ * `bogo_category_msg_create` ajax action (getdokan/storegrowth-sales-booster-pro#241).
+ *
+ * The BOGO category-message handlers write/read the `spsg_bogo_general_settings`
+ * option and must reject unauthenticated callers. After the class fix they are:
+ *   - no longer registered for `wp_ajax_nopriv_*` (a guest hits no handler),
+ *   - guarded by `current_user_can( 'manage_options' )`, and
+ *   - verified against the admin-only `spsg_admin_protected` nonce, which is
+ *     never emitted on the storefront. The frontend now emits only the
+ *     unprivileged `spsg_frontend_protected` cart nonce, so the `ajd_protected`
+ *     nonce a visitor used to scrape is gone entirely.
+ *
+ * A rejected request never reaches `update_option`, so the option is unchanged.
+ * A successful write would echo a truthy `wp_send_json_success` — asserted never
+ * to happen, and our marker never to appear.
+ */
+test.describe('API · bogo category-message authorization', () => {
+  const AJAX = '/wp-admin/admin-ajax.php';
+  const marker = 'sg-regression-marker-241';
+  const writePayload = {
+    action: 'bogo_category_msg_create',
+    'data[id]': '999999',
+    'data[message]': marker,
+    'data[categoryStatus]': 'true',
+  };
+
+  test('anonymous bogo_category_msg_create is rejected and persists nothing', async ({ playwright }) => {
+    const anon = await playwright.request.newContext({ baseURL: env.baseURL });
+
+    // 1. No nonce.
+    const noNonce = await anon.post(AJAX, { form: writePayload });
+    const noNonceBody = (await noNonce.text()).trim();
+    expect([200, 400, 403], 'anon create status').toContain(noNonce.status());
+    expect(['0', '-1'], 'anon create body').toContain(noNonceBody);
+    expect(noNonceBody).not.toContain(marker);
+
+    // 2. Forged nonce.
+    const forged = await anon.post(AJAX, {
+      form: { ...writePayload, _ajax_nonce: 'deadbeef00' },
+    });
+    const forgedBody = (await forged.text()).trim();
+    expect(['0', '-1'], 'forged create body').toContain(forgedBody);
+    expect(forgedBody).not.toContain(marker);
+    expect(forgedBody).not.toContain('"success":true');
+
+    await anon.dispose();
+  });
+
+  test('anonymous bogo_category_msg_list (read) is rejected', async ({ playwright }) => {
+    const anon = await playwright.request.newContext({ baseURL: env.baseURL });
+
+    const res = await anon.post(AJAX, { form: { action: 'bogo_category_msg_list' } });
+    const body = (await res.text()).trim();
+    expect([200, 400, 403]).toContain(res.status());
+    expect(['0', '-1']).toContain(body);
+    expect(body).not.toContain(marker);
+
+    await anon.dispose();
+  });
+});

--- a/tests/e2e/tests/api/create-popup-auth.api.spec.ts
+++ b/tests/e2e/tests/api/create-popup-auth.api.spec.ts
@@ -34,8 +34,8 @@ test.describe('API · sales-pop create_popup authorization', () => {
       form: { action: 'create_popup', data: payload },
     });
     const noNonceBody = (await noNonce.text()).trim();
-    // `0` (no nopriv handler) or `-1`/403 (nonce failure) — both are rejections.
-    expect([200, 403], 'anon create_popup status').toContain(noNonce.status());
+    // `0` with HTTP 400 (no nopriv handler) or `-1`/403 (nonce failure) — both are rejections.
+    expect([200, 400, 403], 'anon create_popup status').toContain(noNonce.status());
     expect(['0', '-1'], 'anon create_popup body').toContain(noNonceBody);
     expect(noNonceBody).not.toContain(marker);
 
@@ -56,7 +56,7 @@ test.describe('API · sales-pop create_popup authorization', () => {
 
     const res = await anon.post(AJAX, { form: { action: 'popup_products', data: '[]' } });
     const body = (await res.text()).trim();
-    expect([200, 403]).toContain(res.status());
+    expect([200, 400, 403]).toContain(res.status());
     expect(['0', '-1']).toContain(body);
 
     await anon.dispose();

--- a/tests/e2e/tests/api/create-popup-auth.api.spec.ts
+++ b/tests/e2e/tests/api/create-popup-auth.api.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '../../fixtures/test';
+import { env } from '../../helpers/env';
+
+/**
+ * Regression for the "Missing Authorization / unauthenticated options update via
+ * `create_popup`" report (getdokan/storegrowth-sales-booster-pro#240), and the
+ * related stored-XSS report (#239).
+ *
+ * The Sales Pop `create_popup` (write) and `popup_products` (read) admin-ajax
+ * actions must reject unauthenticated callers. After the fix they are:
+ *   - no longer registered for `wp_ajax_nopriv_*` (so a guest hits no handler),
+ *   - guarded by `current_user_can( 'manage_options' )`, and
+ *   - verified against the admin-only `spsg_admin_protected` nonce, which is
+ *     never emitted on the storefront — so the frontend `ajd_protected` nonce a
+ *     visitor could scrape cannot authorize these actions.
+ *
+ * A rejected request never reaches `update_option`, so `spsg_popup_products`
+ * stays unchanged. A successful write would instead echo the saved option back
+ * (`wp_send_json_success`) and contain our marker — which we assert never happens.
+ */
+test.describe('API · sales-pop create_popup authorization', () => {
+  const AJAX = '/wp-admin/admin-ajax.php';
+  // If this string ever appears in a success response, an unauthorized write got through.
+  const marker = 'sg-regression-marker-240';
+  const payload = JSON.stringify({
+    popup_data: { message_popup: marker, popup_products: [1] },
+  });
+
+  test('anonymous create_popup is rejected and persists nothing', async ({ playwright }) => {
+    const anon = await playwright.request.newContext({ baseURL: env.baseURL });
+
+    // 1. No nonce — a logged-out caller has no valid admin nonce.
+    const noNonce = await anon.post(AJAX, {
+      form: { action: 'create_popup', data: payload },
+    });
+    const noNonceBody = (await noNonce.text()).trim();
+    // `0` (no nopriv handler) or `-1`/403 (nonce failure) — both are rejections.
+    expect([200, 403], 'anon create_popup status').toContain(noNonce.status());
+    expect(['0', '-1'], 'anon create_popup body').toContain(noNonceBody);
+    expect(noNonceBody).not.toContain(marker);
+
+    // 2. Forged nonce — a scraped/guessed value must not authorize the write.
+    const forged = await anon.post(AJAX, {
+      form: { action: 'create_popup', _ajax_nonce: 'deadbeef00', data: payload },
+    });
+    const forgedBody = (await forged.text()).trim();
+    expect(['0', '-1'], 'forged-nonce create_popup body').toContain(forgedBody);
+    expect(forgedBody).not.toContain(marker);
+    expect(forgedBody).not.toContain('"success":true');
+
+    await anon.dispose();
+  });
+
+  test('anonymous popup_products (read) is rejected', async ({ playwright }) => {
+    const anon = await playwright.request.newContext({ baseURL: env.baseURL });
+
+    const res = await anon.post(AJAX, { form: { action: 'popup_products', data: '[]' } });
+    const body = (await res.text()).trim();
+    expect([200, 403]).toContain(res.status());
+    expect(['0', '-1']).toContain(body);
+
+    await anon.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **missing-authorization** report on `create_popup` (Wordfence — pro issue getdokan/storegrowth-sales-booster-pro#240).

> **Stacked on #543** (base branch = `fix/sales-pop-create-popup-xss`). Review/merge #543 first; this PR's diff is only the nonce-separation + regression test. Rebase onto `develop` once #543 lands.

### The gap

The shared `ajd_protected` nonce is emitted on the **storefront** by the BOGO and Upsell modules (`front_scripts`). Because privileged handlers verified that same nonce, a logged-out visitor could scrape it and reach them. #543 added the `manage_options` gate; this PR closes the nonce namespace gap so a scraped storefront nonce can't even reach a privileged handler.

### The fix — dedicated admin-only nonce `spsg_admin_protected`

- Emitted **only** from the wp-admin `admin_enqueue_scripts` localizes (sales-pop + bogo), reusing the existing `ajd_nonce` localized key → **no JS rebuild**.
- Privileged handlers now verify it: `create_popup`, `popup_products`, `bogo_category_msg_create`, `bogo_category_msg_list`.
- The frontend `ajd_protected` nonce stays scoped to the unprivileged storefront **cart** actions (`offer_product_add_to_cart`, `update_offer_product`, `upsell_offer_product_add_to_cart`), which remain `nopriv` by design.

### Audit (criterion #5)

- **BOGO** — category-message handlers locked (nonce + `manage_options`).
- **Upsell Order Bump** — config is REST-based (`manage_options`); the only ajax handler is the frontend cart action → no missing-cap option write found.

### Regression test (criterion #6)

`tests/e2e/tests/api/create-popup-auth.api.spec.ts` — asserts an unauthenticated `create_popup` / `popup_products` request is rejected and stores nothing.

### Acceptance criteria

- [x] Capability check on the handler (delivered in #543)
- [x] Separate nonce namespaces — distinct admin-only nonce for option-updating actions
- [x] Frontend nonce scoped to unprivileged reads/cart only
- [x] Sanitize `popup_data` before persisting (delivered in #543)
- [x] Audit BOGO + Upsell Order Bump ajax handlers
- [x] Regression test
- [ ] Respond to Wordfence with patch details (external follow-up)

### Compatibility

- Admin UI forwards the `ajd_nonce` value unchanged (now derived from the admin-only nonce) → unaffected.
- Dokan vendors use REST (`dokandar`) → unaffected.

### Verification

- `php -l` clean; `phpcs-changed` clean on all changed lines.
- New API spec compiles and both cases collect (`playwright test --list`). Full run happens in CI (`e2e.yml`) — the wp-env/Docker stack isn't available locally to execute it here.

Refs getdokan/storegrowth-sales-booster-pro#240