### PR TITLE
fix: eliminate shared ajd_protected nonce across BOGO/upsell ajax (CVE-2026-13110, pro#241)

### DIFF
--- a/modules/bogo/includes/Ajax.php
+++ b/modules/bogo/includes/Ajax.php
@@ -46,7 +46,7 @@ class Ajax implements HookRegistry {
 	}
 
 	public function handle_update_offer_product() {
-		check_ajax_referer( 'ajd_protected' );
+		check_ajax_referer( 'spsg_frontend_protected' );
 
 		$data = ! empty( $_POST['data'] ) ? wc_clean( $_POST['data'] ) : array();
 		if ( empty( $data ) ) {
@@ -253,7 +253,7 @@ class Ajax implements HookRegistry {
 	 * Bogo product add to cart.
 	 */
 	public function offer_product_add_to_cart() {
-		check_ajax_referer( 'ajd_protected' );
+		check_ajax_referer( 'spsg_frontend_protected' );
 
 		global $woocommerce;
 		$all_cart_products = $woocommerce->cart->get_cart();

--- a/modules/bogo/includes/EnqueueScript.php
+++ b/modules/bogo/includes/EnqueueScript.php
@@ -92,8 +92,8 @@ class EnqueueScript implements HookRegistry {
 			);
 
 			// Admin-only nonce for privileged option-writing ajax (create/list
-			// category messages). Kept distinct from the frontend `ajd_protected`
-			// nonce so a scraped storefront nonce can't authorize admin actions.
+			// category messages). Kept distinct from the frontend cart nonce so a
+			// scraped storefront nonce can't authorize admin actions.
 			$action    = 'spsg_admin_protected';
 			$ajd_nonce = wp_create_nonce( $action );
 
@@ -170,7 +170,10 @@ class EnqueueScript implements HookRegistry {
 			true
 		);
 
-		$action    = 'ajd_protected';
+		// Frontend-only nonce for the public storefront cart actions
+		// (add/update BOGO gift). Deliberately NOT the admin nonce — a scraped
+		// storefront nonce must never authorize a settings write.
+		$action    = 'spsg_frontend_protected';
 		$ajd_nonce = wp_create_nonce( $action );
 		wp_localize_script(
 			'spsg-bogo-front-js',

--- a/modules/upsell-order-bump/includes/EnqueueScript.php
+++ b/modules/upsell-order-bump/includes/EnqueueScript.php
@@ -58,7 +58,8 @@ class EnqueueScript implements HookRegistry {
 				true
 			);
 
-			$action    = 'ajd_protected';
+			// Admin-only nonce (settings screen). Distinct from the frontend cart nonce.
+			$action    = 'spsg_admin_protected';
 			$ajd_nonce = wp_create_nonce( $action );
 
 			wp_localize_script(
@@ -138,7 +139,8 @@ class EnqueueScript implements HookRegistry {
 			true
 		);
 
-		$action    = 'ajd_protected';
+		// Frontend-only nonce for the public order-bump add-to-cart action.
+		$action    = 'spsg_frontend_protected';
 		$ajd_nonce = wp_create_nonce( $action );
 		wp_localize_script(
 			'spsg-order-bump-front-js',

--- a/modules/upsell-order-bump/includes/OrderBumpAjax.php
+++ b/modules/upsell-order-bump/includes/OrderBumpAjax.php
@@ -31,7 +31,7 @@ class OrderBumpAjax implements HookRegistry {
 	 * Bump product add to cart.
 	 */
 	public function upsell_offer_product_add_to_cart() {
-		check_ajax_referer( 'ajd_protected' );
+		check_ajax_referer( 'spsg_frontend_protected' );
 		
 		global $woocommerce;
 		$all_cart_products = $woocommerce->cart->get_cart();

--- a/tests/e2e/tests/api/bogo-category-msg-auth.api.spec.ts
+++ b/tests/e2e/tests/api/bogo-category-msg-auth.api.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '../../fixtures/test';
+import { env } from '../../helpers/env';
+
+/**
+ * Regression for CVE-2026-13110 — unauthenticated settings modification via the
+ * `bogo_category_msg_create` ajax action (getdokan/storegrowth-sales-booster-pro#241).
+ *
+ * The BOGO category-message handlers write/read the `spsg_bogo_general_settings`
+ * option and must reject unauthenticated callers. After the class fix they are:
+ *   - no longer registered for `wp_ajax_nopriv_*` (a guest hits no handler),
+ *   - guarded by `current_user_can( 'manage_options' )`, and
+ *   - verified against the admin-only `spsg_admin_protected` nonce, which is
+ *     never emitted on the storefront. The frontend now emits only the
+ *     unprivileged `spsg_frontend_protected` cart nonce, so the `ajd_protected`
+ *     nonce a visitor used to scrape is gone entirely.
+ *
+ * A rejected request never reaches `update_option`, so the option is unchanged.
+ * A successful write would echo a truthy `wp_send_json_success` — asserted never
+ * to happen, and our marker never to appear.
+ */
+test.describe('API · bogo category-message authorization', () => {
+  const AJAX = '/wp-admin/admin-ajax.php';
+  const marker = 'sg-regression-marker-241';
+  const writePayload = {
+    action: 'bogo_category_msg_create',
+    'data[id]': '999999',
+    'data[message]': marker,
+    'data[categoryStatus]': 'true',
+  };
+
+  test('anonymous bogo_category_msg_create is rejected and persists nothing', async ({ playwright }) => {
+    const anon = await playwright.request.newContext({ baseURL: env.baseURL });
+
+    // 1. No nonce.
+    const noNonce = await anon.post(AJAX, { form: writePayload });
+    const noNonceBody = (await noNonce.text()).trim();
+    expect([200, 403], 'anon create status').toContain(noNonce.status());
+    expect(['0', '-1'], 'anon create body').toContain(noNonceBody);
+    expect(noNonceBody).not.toContain(marker);
+
+    // 2. Forged nonce.
+    const forged = await anon.post(AJAX, {
+      form: { ...writePayload, _ajax_nonce: 'deadbeef00' },
+    });
+    const forgedBody = (await forged.text()).trim();
+    expect(['0', '-1'], 'forged create body').toContain(forgedBody);
+    expect(forgedBody).not.toContain(marker);
+    expect(forgedBody).not.toContain('"success":true');
+
+    await anon.dispose();
+  });
+
+  test('anonymous bogo_category_msg_list (read) is rejected', async ({ playwright }) => {
+    const anon = await playwright.request.newContext({ baseURL: env.baseURL });
+
+    const res = await anon.post(AJAX, { form: { action: 'bogo_category_msg_list' } });
+    const body = (await res.text()).trim();
+    expect([200, 403]).toContain(res.status());
+    expect(['0', '-1']).toContain(body);
+    expect(body).not.toContain(marker);
+
+    await anon.dispose();
+  });
+});

--- a/tests/e2e/tests/api/bogo-category-msg-auth.api.spec.ts
+++ b/tests/e2e/tests/api/bogo-category-msg-auth.api.spec.ts
@@ -34,7 +34,7 @@ test.describe('API · bogo category-message authorization', () => {
     // 1. No nonce.
     const noNonce = await anon.post(AJAX, { form: writePayload });
     const noNonceBody = (await noNonce.text()).trim();
-    expect([200, 403], 'anon create status').toContain(noNonce.status());
+    expect([200, 400, 403], 'anon create status').toContain(noNonce.status());
     expect(['0', '-1'], 'anon create body').toContain(noNonceBody);
     expect(noNonceBody).not.toContain(marker);
 
@@ -55,7 +55,7 @@ test.describe('API · bogo category-message authorization', () => {
 
     const res = await anon.post(AJAX, { form: { action: 'bogo_category_msg_list' } });
     const body = (await res.text()).trim();
-    expect([200, 403]).toContain(res.status());
+    expect([200, 400, 403]).toContain(res.status());
     expect(['0', '-1']).toContain(body);
     expect(body).not.toContain(marker);
 


### PR DESCRIPTION
## Summary

Closes the third report of the shared-nonce / `nopriv` pattern — unauthenticated settings modification via `bogo_category_msg_create` (**CVE-2026-13110**, Wordfence/PRISM — pro issue getdokan/storegrowth-sales-booster-pro#241).

> **Stacked on #544 → #543.** Base branch = `fix/popup-ajax-authorization`. Merge order: **#543 → #544 → this**. This PR's diff is only the frontend-nonce elimination + BOGO regression tests.

### The pattern (three reports, one root cause)

`ajd_protected` was a **single ambiguous nonce** that authorized *both* public storefront cart actions *and* privileged option writes, **and was emitted on every public page**. A logged-out visitor could scrape it and drive an admin settings write (`spsg_bogo_general_settings`, `spsg_popup_products`).

#543 + #544 already closed the handler side (removed `nopriv`, added `manage_options`, moved privileged handlers to the admin-only `spsg_admin_protected` nonce). This PR removes the **last** piece: the `ajd_protected` literal itself, so no privileged-looking nonce is ever emitted on a public page.

### The fix — one nonce → two clearly-scoped nonces

`ajd_protected` is **removed entirely**. In its place:

| Nonce | Scope | Emitted on | Verified by |
|-------|-------|-----------|-------------|
| `spsg_admin_protected` | privileged option read/write | settings screen only (`admin_enqueue_scripts`) | `create_popup`, `popup_products`, `bogo_category_msg_create`, `bogo_category_msg_list` |
| `spsg_frontend_protected` | unprivileged cart mutation | storefront (`front_scripts`) | `offer_product_add_to_cart`, `update_offer_product`, `upsell_offer_product_add_to_cart` |

The localized `ajd_nonce` **key is unchanged**, so the cart JS keeps forwarding whatever value it's given → **no JS rebuild**.

### BOGO `nopriv` audit (criterion #5)

| Handler | Classification | Action |
|---------|---------------|--------|
| `bogo_category_msg_create` / `_list` | admin (settings write/read) | nopriv removed + `manage_options` + admin nonce (in #543/#544) |
| `offer_product_add_to_cart` | **public** (guest claims gift) | stays `nopriv`; now the frontend-only nonce |
| `update_offer_product` | **public** (guest updates gift) | stays `nopriv`; now the frontend-only nonce |
| `save_settings` / `get_settings` | admin | already `spsg_ajax_nonce`, `wp_ajax` only |

`offer_product_add_to_cart` / `update_offer_product` only mutate the visitor's own cart session (no option write), so a `manage_options` check would break guest checkout and is intentionally **not** applied — the correct classification per criterion #5.

### Sanitization (criterion #7)

`bogo_category_msg_create` already runs `wc_clean()` over the payload (recursive `sanitize_text_field`), so stored fields are sanitized.

### Regression tests (criterion #8)

`tests/e2e/tests/api/bogo-category-msg-auth.api.spec.ts` — asserts unauthenticated `bogo_category_msg_create` / `bogo_category_msg_list` are rejected and store nothing.

### Acceptance criteria

- [x] Remove `wp_ajax_nopriv_bogo_category_msg_create` (in #543)
- [x] `current_user_can('manage_options')` on `bogo_category_msg_create` (in #543)
- [x] Same check on `bogo_category_msg_list` (in #543); `offer_product_add_to_cart` classified public (criterion #5)
- [x] Stop emitting `ajd_protected` from `front_scripts()` — the literal is gone entirely
- [x] Audit every BOGO `nopriv` registration and classify
- [x] Distinct admin-only nonce for privileged actions
- [x] Sanitize the `data` payload before persisting (`wc_clean`)
- [x] Regression tests
- [ ] Submit patch details to Wordfence (external follow-up)

### Verification

- `php -l` clean; `phpcs-changed` clean on all changed lines.
- `grep -rn ajd_protected --include=*.php` over `modules/`, `integrations/`, `includes/` → **no matches**.
- New API spec compiles and both cases collect (`playwright test --list`). Full run happens in CI (`e2e.yml`).

Refs getdokan/storegrowth-sales-booster-pro#241