### PR TITLE
fix: resolve missing dependency for Dokan admin scripts

### DIFF
--- a/integrations/includes/Dokan/Admin/EnqueueScript.php
+++ b/integrations/includes/Dokan/Admin/EnqueueScript.php
@@ -4,6 +4,7 @@ namespace StorePulse\StoreGrowth\Integrations\Dokan\Admin;
 
 use StorePulse\StoreGrowth\Traits\Singleton;
 use StorePulse\StoreGrowth\Helper;
+use StorePulse\StoreGrowth\ModuleManager;
 
 /**
  * Admin EnqueueScript Class.
@@ -37,38 +38,63 @@ class EnqueueScript {
      *
      * @since 1.12.0
      *
+     * @param string $hook Current admin screen hook suffix.
+     *
+     * @return void
      */
-    public function admin_enqueue_scripts() {
-        $admin_file     = require Helper::get_plugin_path( 'integrations/assets/build/bogo-dokan-admin.asset.php' );
-        $admin_file     = require Helper::get_plugin_path( 'integrations/assets/build/bogo-dokan-admin.asset.php' );
-        $flycart_file   = require Helper::get_plugin_path( 'integrations/assets/build/dokan-fly-cart.asset.php' );
-        $countdown_file = require Helper::get_plugin_path( 'integrations/assets/build/dokan-countdown-timer.asset.php' );
+    public function admin_enqueue_scripts( $hook = '' ) {
+        // These bundles only extend the StoreGrowth settings SPA, so bail on
+        // every other admin screen instead of shipping React plugin-wide.
+        if ( 'storegrowth_page_spsg-settings' !== $hook ) {
+            return;
+        }
 
-        if ( file_exists( Helper::get_plugin_path( 'integrations/assets/build/bogo-dokan-admin.js' ) ) ) {
+        $modules = new ModuleManager();
+
+        // `spsg-bogo-dokan-admin` registers a `spsg_bogo_tab_panels` filter that
+        // only the BOGO module's settings bundle consumes. Enqueuing it while the
+        // module is inactive leaves its dependency unregistered and WP drops the
+        // script with a "Missing Dependencies" notice.
+        if (
+            $modules->is_active_module( 'bogo' )
+            && file_exists( Helper::get_plugin_path( 'integrations/assets/build/bogo-dokan-admin.js' ) )
+        ) {
+            $admin_file = require Helper::get_plugin_path( 'integrations/assets/build/bogo-dokan-admin.asset.php' );
+
             wp_enqueue_script(
                 'spsg-bogo-dokan-admin',
                 Helper::get_integrations_path( 'assets/build/bogo-dokan-admin.js' ),
-                array_merge( $admin_file['dependencies'], [ 'spsg-bogo-admin-script' ] ),
+                array_merge( $admin_file['dependencies'], [ 'spsg-bogo-settings' ] ),
                 $admin_file['version'],
                 true
             );
         }
 
-        if ( file_exists( Helper::get_plugin_path( 'integrations/assets/build/dokan-fly-cart.js' ) ) ) {
+        if (
+            $modules->is_active_module( 'fly-cart' )
+            && file_exists( Helper::get_plugin_path( 'integrations/assets/build/dokan-fly-cart.js' ) )
+        ) {
+            $flycart_file = require Helper::get_plugin_path( 'integrations/assets/build/dokan-fly-cart.asset.php' );
+
             wp_enqueue_script(
                 'spsg-dokan-fly-cart',
                 Helper::get_integrations_path( 'assets/build/dokan-fly-cart.js' ),
-                $flycart_file['dependencies'] ,
+                $flycart_file['dependencies'],
                 $flycart_file['version'],
                 true
             );
         }
 
-        if ( file_exists( Helper::get_plugin_path( 'integrations/assets/build/dokan-countdown-timer.js' ) ) ) {
+        if (
+            $modules->is_active_module( 'countdown-timer' )
+            && file_exists( Helper::get_plugin_path( 'integrations/assets/build/dokan-countdown-timer.js' ) )
+        ) {
+            $countdown_file = require Helper::get_plugin_path( 'integrations/assets/build/dokan-countdown-timer.asset.php' );
+
             wp_enqueue_script(
                 'spsg-dokan-countdown-timer',
                 Helper::get_integrations_path( 'assets/build/dokan-countdown-timer.js' ),
-                $countdown_file['dependencies'] ,
+                $countdown_file['dependencies'],
                 $countdown_file['version'],
                 true
             );


### PR DESCRIPTION
- Closes getdokan/plugin-internal-tasks#2161

### Problem

With Dokan active and the BOGO module **deactivated**, WordPress dropped `spsg-bogo-dokan-admin` on every admin page:

```
Missing Dependencies
spsg-bogo-dokan-admin    dokan.test
integrations/assets/build/bogo-dokan-admin.js
react, react-dom, react-jsx-runtime, wp-data, wp-element, wp-hooks, wp-i18n,
spsg-bogo-admin-script (missing)
```

`Admin\EnqueueScript` enqueued the bundle on every admin screen with a hardcoded `spsg-bogo-admin-script` dependency, but that handle is registered only when the BOGO module is active (`modules/bogo/includes/EnqueueScript.php:55`). Nothing in the Dokan integration checks module state — `ServiceProvider::boot()` boots it whenever `dokan()` exists.

The dependency was also the wrong handle. `spsg-bogo-admin-script` is the jQuery product-edit script (`product-bogo-settings.js`); `bogo-dokan-admin.js` only calls `addFilter('spsg_bogo_tab_panels', …)`, which is consumed by `spsg-bogo-settings`, the React settings bundle.

### Changes

All in `integrations/includes/Dokan/Admin/EnqueueScript.php`:

- Bail unless `$hook === 'storegrowth_page_spsg-settings'`. All three bundles here (BOGO, fly-cart, countdown-timer) are settings-SPA filter extensions, so the React payload no longer ships on every wp-admin page.
- Gate each bundle on its own module via `ModuleManager::is_active_module()` — `bogo`, `fly-cart`, `countdown-timer`.
- Depend on `spsg-bogo-settings` instead of `spsg-bogo-admin-script`.
- Move each `require *.asset.php` inside its `file_exists()` guard, so a missing build artifact skips instead of fataling.
- Drop a duplicated `require` of `bogo-dokan-admin.asset.php`.

### Notes

Filter timing is unaffected. `applyFilters( 'spsg_bogo_tab_panels' )` runs inside the `BogoTabLayout` render (`modules/bogo/assets/src/components/BogoTabLayout.jsx:52`), which happens after all footer scripts execute — so `spsg-bogo-dokan-admin` printing after `spsg-bogo-settings` still registers the panel in time.

Indentation follows the existing 4-space style of `integrations/`; PHPCS reports only the pre-existing tab-vs-space violations for this file.

### Testing

1. WooCommerce + Dokan + StoreGrowth active.
2. Deactivate the BOGO module → no "Missing Dependencies" notice on any admin page; `spsg-bogo-dokan-admin` is not enqueued.
3. Activate the BOGO module → StoreGrowth → Settings → BOGO shows the **Vendors** tab.
4. Any other admin screen (Posts, Products, Dashboard) → none of the three integration bundles are enqueued.
5. Same checks for the fly-cart and countdown-timer vendor settings.
