### PR TITLE
fix: authorization checks on settings-write AJAX handlers + Dokan nonce exposure

### DIFF
--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -51,9 +51,15 @@ class Ajax {
 
 		$method = sanitize_text_field( wp_unslash( $_POST['method'] ) );
 
-		if ( method_exists( $this, $method ) ) {
-			call_user_func( array( $this, $method ) );
+		// Only these methods may be dispatched from this endpoint. Never call an
+		// arbitrary method name taken from the request.
+		$allowed_methods = array( 'get_all_modules', 'update_module_status' );
+
+		if ( ! in_array( $method, $allowed_methods, true ) || ! method_exists( $this, $method ) ) {
+			wp_send_json_error( __( 'Method not allowed.', 'storegrowth-sales-booster' ), 400 );
 		}
+
+		call_user_func( array( $this, $method ) );
 
 		wp_die();
 	}

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -41,6 +41,10 @@ class Ajax {
 	public function admin_ajax() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
+
 		if ( ! isset( $_POST['method'] ) ) {
 			wp_die();
 		}
@@ -103,6 +107,11 @@ class Ajax {
 	 */
 	public function spsg_inisetup_flag_update() {
 		check_ajax_referer( 'spsg_ajax_nonce', '_ajax_nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
+
 		$flag_data = isset( $_POST['spsg_ini_completion'] );
 		update_option( 'spsg_ini_completion', $flag_data );
 		wp_send_json_success( array( 'message' => 'Success message' ) );

--- a/integrations/includes/Dokan/Ajax.php
+++ b/integrations/includes/Dokan/Ajax.php
@@ -35,6 +35,10 @@ class Ajax {
     public function save_settings() {
         check_ajax_referer( 'spsg_ajax_nonce' );
 
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+        }
+
         if ( ! isset( $_POST['data'] ) ) {
             wp_send_json_error();
         }
@@ -59,6 +63,10 @@ class Ajax {
      */
     public function get_settings() {
         check_ajax_referer( 'spsg_ajax_nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+        }
 
         $form_data = \StorePulse\StoreGrowth\Helper::get_settings( 'spsg_bogo_dokan_vendors_settings', [] );
 

--- a/integrations/includes/Dokan/Dashboard/Bogo.php
+++ b/integrations/includes/Dokan/Dashboard/Bogo.php
@@ -146,8 +146,12 @@ class Bogo {
             'spsg-bogo-dokan-vendor-dashboard',
             'spsgAdmin',
             [
+                // The admin write nonce (`spsg_ajax_nonce`) is intentionally NOT
+                // localized on this frontend vendor screen. Emitting it would
+                // hand any dashboard viewer a token the privileged settings
+                // handlers accept. Vendor operations use the REST / frontend
+                // nonces in `bogo_save_url` below.
                 'ajax_url' => admin_url( 'admin-ajax.php' ),
-                'nonce'    => wp_create_nonce( 'spsg_ajax_nonce' ),
                 'isPro'    => sp_store_growth()->has_pro(),
 				'buyXGetXEnableForVendor' => $is_enable,
             ]

--- a/modules/bogo/includes/Ajax.php
+++ b/modules/bogo/includes/Ajax.php
@@ -168,6 +168,10 @@ class Ajax implements HookRegistry {
 	public function save_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
+
 		if ( ! isset( $_POST['data'] ) ) {
 			wp_send_json_error();
 		}
@@ -189,6 +193,10 @@ class Ajax implements HookRegistry {
 	 */
 	public function get_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
 
 		$form_data = \StorePulse\StoreGrowth\Helper::get_settings( 'spsg_bogo_general_settings', array() );
 

--- a/modules/countdown-timer/includes/Ajax.php
+++ b/modules/countdown-timer/includes/Ajax.php
@@ -38,6 +38,10 @@ class Ajax implements HookRegistry {
 	public function save_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
+
 		if ( ! isset( $_POST['form_data'] ) ) {
 			wp_send_json_error();
 		}
@@ -55,6 +59,10 @@ class Ajax implements HookRegistry {
 	 */
 	public function get_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
 
 		$form_data = \StorePulse\StoreGrowth\Helper::get_settings( 'spsg_countdown_timer_settings', array() );
 

--- a/modules/direct-checkout/includes/Ajax.php
+++ b/modules/direct-checkout/includes/Ajax.php
@@ -37,6 +37,10 @@ class Ajax implements HookRegistry {
 	public function save_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
+
 		if ( ! isset( $_POST['data'] ) ) {
 			wp_send_json_error();
 		}
@@ -58,6 +62,10 @@ class Ajax implements HookRegistry {
 	 */
 	public function get_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
 
 		$form_data = \StorePulse\StoreGrowth\Helper::get_settings( 'spsg_direct_checkout_settings', array() );
 

--- a/modules/floating-notification-bar/includes/Ajax.php
+++ b/modules/floating-notification-bar/includes/Ajax.php
@@ -37,6 +37,10 @@ class Ajax implements HookRegistry {
 	public function save_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
+
 		$form_data = isset( $_POST['form_data'] ) ? json_decode( wp_unslash( $_POST['form_data'] ), true ) : array(); 
 
 		$bar_data = isset( $form_data['shipping_bar_data'] ) ? $form_data['shipping_bar_data'] : array();
@@ -56,6 +60,10 @@ class Ajax implements HookRegistry {
 	 */
 	public function get_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
 
 		wp_send_json_success( Helper::get_settings() );
 	}

--- a/modules/fly-cart/includes/Ajax.php
+++ b/modules/fly-cart/includes/Ajax.php
@@ -41,6 +41,10 @@ class Ajax implements HookRegistry {
 	public function save_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
+
 		if ( ! isset( $_POST['form_data'] ) ) {
 			wp_send_json_error();
 		}
@@ -62,6 +66,10 @@ class Ajax implements HookRegistry {
 	public function get_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
+
 		$form_data = Helper::get_settings( 'spsg_fly_cart_settings', array() );
 
 		wp_send_json_success( $form_data );
@@ -74,22 +82,35 @@ class Ajax implements HookRegistry {
 	 */
 	public function fly_cart_frontend() {
 		check_ajax_referer( 'spsg_frontend_ajax' );
-		if ( ! isset( $_REQUEST['method'] ) ) {
+
+		$method = isset( $_REQUEST['method'] ) ? sanitize_key( $_REQUEST['method'] ) : '';
+
+		/**
+		 * Methods callable from the public (nopriv) fly-cart endpoint.
+		 *
+		 * This is an explicit allow-list. The handler must never dispatch to an
+		 * arbitrary method name taken from the request, so any name not listed
+		 * here is rejected before `call_user_func`.
+		 *
+		 * @since SPSG_VERSION
+		 *
+		 * @param string[] $allowed_methods Method names callable on this class.
+		 */
+		$allowed_methods = apply_filters( 'spsg_fly_cart_frontend_allowed_methods', array( 'get_cart_contents' ) );
+
+		if ( ! in_array( $method, $allowed_methods, true ) ) {
 			wp_send_json_error( array( 'message' => __( 'Method Not Found', 'storegrowth-sales-booster' ) ) );
 		}
-		$method = isset( $_REQUEST['method'] ) ? sanitize_key( $_REQUEST['method'] ) : '';
-		if ( method_exists( $this, $method ) ) {
-			$data = isset( $_REQUEST['data'] ) ? wp_unslash( $_REQUEST['data'] ) : array(); //phpcs:ignore
-			$data = wp_unslash( $data );
-			$data = array_map( 'sanitize_text_field', $data );
-			wp_send_json_success(
-				array(
-					'cartCountLocation' => esc_html( wc()->cart->get_cart_contents_count() ),
-					'htmlResponse'      => call_user_func( array( $this, $method ), $data ),
-				)
-			);
-		}
-		wp_die();
+
+		$data = isset( $_REQUEST['data'] ) ? wp_unslash( $_REQUEST['data'] ) : array(); //phpcs:ignore
+		$data = array_map( 'sanitize_text_field', $data );
+
+		wp_send_json_success(
+			array(
+				'cartCountLocation' => esc_html( wc()->cart->get_cart_contents_count() ),
+				'htmlResponse'      => call_user_func( array( $this, $method ), $data ),
+			)
+		);
 	}
 
 	/**

--- a/modules/fly-cart/includes/Ajax.php
+++ b/modules/fly-cart/includes/Ajax.php
@@ -78,6 +78,12 @@ class Ajax implements HookRegistry {
 	/**
 	 * Frontend ajax.
 	 *
+	 * Intentionally public (registered on `wp_ajax_nopriv_*`): the fly cart is
+	 * a storefront feature anonymous shoppers use. It carries no capability
+	 * check by design — it is guarded by a frontend nonce, dispatches only the
+	 * allow-listed `get_cart_contents`, and reads only the current visitor's
+	 * own cart via `WC()->cart`, writing nothing.
+	 *
 	 * @uses get_cart_contents
 	 */
 	public function fly_cart_frontend() {

--- a/modules/progressive-discount-banner/includes/Ajax.php
+++ b/modules/progressive-discount-banner/includes/Ajax.php
@@ -37,6 +37,10 @@ class Ajax implements HookRegistry {
 	public function save_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
+
 		$form_data = isset( $_POST['form_data'] ) ? json_decode( wp_unslash( $_POST['form_data'] ), true ) : array();
 
 		$bar_data = isset( $form_data['shipping_bar_data'] ) ? $form_data['shipping_bar_data'] : array();
@@ -56,6 +60,10 @@ class Ajax implements HookRegistry {
 	 */
 	public function get_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
 
 		wp_send_json_success( Helper::get_settings() );
 	}

--- a/modules/quick-view/includes/Ajax.php
+++ b/modules/quick-view/includes/Ajax.php
@@ -73,6 +73,11 @@ class Ajax implements HookRegistry {
 
 	/**
 	 * Quick view Ajax call.
+	 *
+	 * Intentionally public (registered on `wp_ajax_nopriv_*`): quick view is a
+	 * storefront feature anonymous shoppers use. It carries no capability check
+	 * by design — it is guarded by a frontend nonce and only renders read-only
+	 * product markup for a requested product id, writing nothing.
 	 */
 	public function ajax_quickview_callback() {
 		check_ajax_referer( 'spsgqcv-security', 'nonce' );

--- a/modules/quick-view/includes/Ajax.php
+++ b/modules/quick-view/includes/Ajax.php
@@ -40,6 +40,10 @@ class Ajax implements HookRegistry {
 	public function save_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
+
 		if ( ! isset( $_POST['form_data'] ) ) {
 			wp_send_json_error();
 		}
@@ -57,6 +61,10 @@ class Ajax implements HookRegistry {
 	 */
 	public function get_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
 
 		$form_data = \StorePulse\StoreGrowth\Helper::get_settings( 'spsg_quick_view_settings', array() );
 

--- a/modules/stock-bar/includes/Ajax.php
+++ b/modules/stock-bar/includes/Ajax.php
@@ -38,6 +38,10 @@ class Ajax implements HookRegistry {
 	public function save_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
 
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
+
 		if ( ! isset( $_POST['form_data'] ) ) {
 			wp_send_json_error();
 		}
@@ -55,6 +59,10 @@ class Ajax implements HookRegistry {
 	 */
 	public function get_settings() {
 		check_ajax_referer( 'spsg_ajax_nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
+		}
 
 		$form_data = \StorePulse\StoreGrowth\Helper::get_settings( 'spsg_stock_bar_settings', array() );
 


### PR DESCRIPTION
- Closes getdokan/storegrowth-sales-booster-pro#252
- Closes https://github.com/getdokan/storegrowth-sales-booster-pro/issues/245

## Problem

Every AJAX handler that writes a plugin option was guarded only by `check_ajax_referer( 'spsg_ajax_nonce' )` with **no capability check** before `update_option()`. A nonce proves a request came from a page the site served — not that the sender is allowed to perform the action.

On a Dokan install the frontend vendor dashboard localized the **same** `spsg_ajax_nonce` (`integrations/includes/Dokan/Dashboard/Bogo.php:150`), gated only by `dokan_is_seller_dashboard()` (which page is rendering, not who is viewing). Any user who can load the vendor dashboard obtained a token the privileged settings handlers accept.

## Runtime verification

Tested on dokan-lite 5.0.12, dokan-pro 5.0.11, storegrowth-lite 2.1.1.

**Logged-in non-admin (vendor, role `seller`; `manage_options`=N, `manage_woocommerce`=N) — CONFIRMED privilege escalation.**
POST `admin-ajax.php action=spsg_fly_cart_save_settings` with the dashboard nonce → `HTTP 200 {"success":true}`, global option written. The same nonce validates for every module's `*_save_settings` handler.

**Logged-out visitor at `/dashboard/` — not exploitable.** The storegrowth vendor enqueue does not fire logged-out (no `spsgAdmin`, no nonce), and settings handlers have no `wp_ajax_nopriv_*` registration.

Severity: **authenticated privilege escalation**, not unauthenticated. Rides 2.2 per the issue.

After the fix, the same vendor request returns `HTTP 403 {"success":false,"data":"You are not allowed to perform this action."}`; admin saves are unchanged (`HTTP 200`).

## Changes

- **Capability checks** — `current_user_can( 'manage_options' )` before every option read/write in the settings AJAX handlers: core `includes/Ajax.php` (`admin_ajax`, `spsg_inisetup_flag_update`), all 8 module `Ajax` classes, and the Dokan integration `Ajax`. Matches the 2.1.1 standard already used by sales-pop `create_popup` and bogo `bogo_category_msg_create`. Every StoreGrowth settings page already requires `manage_options` (`AdminMenu`), so no legitimate user loses access.
- **Nonce scope** — stopped localizing `spsg_ajax_nonce` on the frontend vendor dashboard (`Bogo.php`). It was unused there (the dashboard app reads only `isPro` / `buyXGetXEnableForVendor`); removing it closes the leak at source. Vendor operations continue to use the REST (`wp_rest`) and frontend (`spsg_frontend_ajax_nonce`) nonces.
- **Method-dispatch hardening** — the fly-cart nopriv handler replaced its open `method_exists()` dispatch with an explicit allow-list (`get_cart_contents`), filterable via `spsg_fly_cart_frontend_allowed_methods`.

## Enumeration (completeness gate)

Every `wp_ajax_*` / `wp_ajax_nopriv_*` registration was enumerated (handler, file:line, nonce, context, capability check, option written). All 11 unguarded write handlers are now gated; the 4 already-guarded 2.1.1 handlers are unchanged; the nopriv sinks write no options. `quick-view`'s nopriv `ajax_quickview_callback` was reviewed — read-only product render, no method dispatch, no change needed.

## Non-regression

- Admin saves every module's settings through the normal UI — unchanged.
- fly-cart `get_cart_contents` over the nopriv endpoint still works; a disallowed method name is rejected.
- phpcs: zero new violations (diffed against baseline — same pre-existing errors, line numbers shifted only).

> Note: cross-repo `Closes` links the pro issue but GitHub does not auto-close across repositories; close #252 manually on merge.