### PR TITLE
fix: Helper::is_module_active() always returned false

### DIFF
--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -204,10 +204,12 @@ class Helper {
 	 * @return boolean True if the module is active, false otherwise.
 	 */
 	public static function is_module_active( string $module_id ): bool {
-		$modules        = new ModuleManager();
-		$active_modules = $modules->get_active_modules();
+		// `get_active_modules()` returns ModuleSkeleton objects, so a string ID
+		// is never strictly equal to any element. Resolve by ID and read the
+		// module's own state instead, which also returns false for unknown IDs.
+		$modules = new ModuleManager();
 
-		return in_array( $module_id, $active_modules, true );
+		return $modules->is_active_module( $module_id );
 	}
 
 	/**

--- a/modules/floating-notification-bar/includes/EnqueueScript.php
+++ b/modules/floating-notification-bar/includes/EnqueueScript.php
@@ -10,6 +10,7 @@ namespace StorePulse\StoreGrowth\Modules\FloatingNotificationBar;
 use StorePulse\StoreGrowth\Interfaces\HookRegistry;
 use StorePulse\StoreGrowth\Traits\Singleton;
 use StorePulse\StoreGrowth\Helper as PluginHelper;
+use StorePulse\StoreGrowth\Modules\ProgressiveDiscountBanner\Helper as PD_Helper;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
- Closes getdokan/storegrowth-sales-booster-pro#251

## Problem

`Helper::is_module_active()` (`includes/Helper.php:206`) did:

```php
$active_modules = $modules->get_active_modules();
return in_array( $module_id, $active_modules, true );
```

`get_active_modules()` returns an array of `ModuleSkeleton` **objects**, so a string module ID is never strictly equal to any element — the method returned `false` for every module in every state.

Its only caller is the Floating Notification Bar (`modules/floating-notification-bar/includes/EnqueueScript.php:64`), which checks whether the Progressive Discount Banner is active to offset its own vertical position. The check always failed, so the two bars overlapped when both were active at the same position.

## Fix

Delegate to the existing, correct `ModuleManager::is_active_module()`, which resolves the module by ID (`get()`) and reads its own `is_active()` state — and returns `false` for unknown IDs rather than erroring. `BaseModule::is_active()` is untouched.

## Verification (runtime)

```
bogo                        => true
progressive-discount-banner => true
floating-notification-bar   => true
sales-pop                   => true
nonexistent-xyz             => false
```

## Acceptance criteria
- ✅ Correct boolean for every module ID (active/inactive); unknown ID → `false`, no error.
- ✅ Both bars active + same position → stack (the caller now offsets correctly).
- ✅ Only-Floating-Bar-active behaviour unchanged (`is_module_active` returns `false` for the banner, same branch as before).
- ✅ `BaseModule::is_active()` unchanged.
- ✅ Sole caller audited (lite + pro grep) — it consumes the correct value; nothing depended on the always-`false` behaviour.

## Merchant note (changelog)
Stores running both the Floating Bar and Free Shipping Bar at the same position will see their layout change from overlapping to stacked — a fix, but a visible one.

> Cross-repo `Closes` links the pro issue but GitHub won't auto-close across repos; close #251 by hand on merge.