### PR TITLE
fix: declare HPOS compatibility and correct the WordPress version floor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ To add a module: create the directory following the shape above, add its `requir
 - Singletons use the `Traits\Singleton` trait.
 - All user-facing strings use text domain `storegrowth-sales-booster`.
 - Extension points are WordPress hooks: `storegrowth_before_load`, `storegrowth_loaded`, `storegrowth_module_before_boot`/`_after_boot`, filter `storegrowth_pro_is_active` (gates pro features).
+- **HPOS (High-Performance Order Storage):** both plugins declare `custom_order_tables` compatibility on `before_woocommerce_init`. This is only honest while the plugin reads orders through `wc_get_orders()` and stores order / order-item data through the WooCommerce CRUD API (`$order->update_meta_data()` / `$order->save()`), **never** `update_post_meta()` on an order ID. Any new code that writes order data must use the CRUD API or the HPOS declaration must be revisited.
 
 ### Version placeholder — REQUIRED when writing code
 When adding any new symbol, **always** tag it with the literal placeholder `SPSG_VERSION` in its `@since` (and `@deprecated`) docblock tag — never hardcode a version number. This applies to new functions, classes, methods, properties, parameters, hooks (`do_action`/`apply_filters`), and REST routes. Example:

--- a/includes/Bootstrap.php
+++ b/includes/Bootstrap.php
@@ -29,12 +29,22 @@ class Bootstrap {
 	public ?Tracker $tracker = null;
 
 	/**
+	 * Minimum WooCommerce version the plugin supports.
+	 *
+	 * @since SPSG_VERSION
+	 *
+	 * @var string
+	 */
+	const MIN_WC_VERSION = '8.0';
+
+	/**
 	 * Constructor of Bootstrap class.
 	 */
 	private function __construct() {
 		$this->tracker = new Tracker();
 		add_action( 'woocommerce_loaded', [ $this, 'on_wc_loaded' ] );
 		add_action( 'admin_notices', [ $this, 'show_notice_if_wc_is_not_active' ] );
+		add_action( 'admin_notices', [ $this, 'show_notice_if_wc_below_minimum' ] );
 	}
 
 	public function show_notice_if_wc_is_not_active(): void {
@@ -49,6 +59,29 @@ class Bootstrap {
 		);
 
 		printf( '<div class="%1$s"><p><strong>%2$s</strong></p></div>', esc_attr( 'notice notice-error' ), wp_kses_post( $message ) );
+	}
+
+	/**
+	 * Warn, without disabling anything, when WooCommerce is older than the
+	 * supported floor.
+	 *
+	 * @since SPSG_VERSION
+	 *
+	 * @return void
+	 */
+	public function show_notice_if_wc_below_minimum(): void {
+		if ( ! defined( 'WC_VERSION' ) || version_compare( WC_VERSION, self::MIN_WC_VERSION, '>=' ) ) {
+			return;
+		}
+
+		$message = sprintf(
+			// translators: 1: required WooCommerce version, 2: active WooCommerce version.
+			__( 'StoreGrowth is built for WooCommerce %1$s or newer. You are running %2$s; please update WooCommerce for full compatibility.', 'storegrowth-sales-booster' ),
+			esc_html( self::MIN_WC_VERSION ),
+			esc_html( WC_VERSION )
+		);
+
+		printf( '<div class="%1$s"><p><strong>%2$s</strong></p></div>', esc_attr( 'notice notice-warning' ), wp_kses_post( $message ) );
 	}
 
 	public function on_wc_loaded(): void {

--- a/includes/ModuleManager.php
+++ b/includes/ModuleManager.php
@@ -120,10 +120,15 @@ class ModuleManager {
 	 * @return ModuleSkeleton|null
 	 */
 	public function get( string $module_id ): ?ModuleSkeleton {
-		$module =  array_find( $this->get_all(), function ( ModuleSkeleton $module ) use ( $module_id ) {
-			return $module->get_id() === $module_id;
-		} );
+		// A plain loop instead of array_find(): the latter is a PHP 8.4 function
+		// only polyfilled by WordPress core from 6.8 onward, so it fataled when
+		// toggling a module on WordPress < 6.8 with PHP < 8.4.
+		foreach ( $this->get_all() as $module ) {
+			if ( $module->get_id() === $module_id ) {
+				return $module;
+			}
+		}
 
-		return $module;
+		return null;
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,7 +16,7 @@
     <exclude-pattern>modules/direct-checkout/assets/*</exclude-pattern>
     <exclude-pattern>modules/upsell-order-bump/assets/*</exclude-pattern>
     <!-- Configs -->
-    <config name="minimum_supported_wp_version" value="5.0" />
+    <config name="minimum_supported_wp_version" value="6.2" />
     <config name="testVersion" value="7.4-"/>
 
     <arg name="basepath" value="."/>

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,11 @@
 Contributors: wedevs, tareq1988, nizamuddinbabu
 Tags: BOGO, Upsells, Direct Checkout, Quick View, Order Bumps
 
-Requires at least: 5.4
+Requires at least: 6.2
 Tested up to: 7.0
 Stable tag: 2.1.1
 Requires PHP: 7.4
+WC requires at least: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/storegrowth-sales-booster.php
+++ b/storegrowth-sales-booster.php
@@ -10,9 +10,10 @@
  * Text Domain: storegrowth-sales-booster
  * Domain Path: /languages
  * Requires Plugins: woocommerce
- * Requires at least: 6.8
+ * Requires at least: 6.2
  * Requires PHP: 7.4
- * 
+ * WC requires at least: 8.0
+ *
  * @package SPSG
  */
 
@@ -80,6 +81,24 @@ register_activation_hook(
 	__FILE__,
 	function () {
 		add_option( 'storegrowth_activation_redirect', true );
+	}
+);
+
+/**
+ * Declare compatibility with WooCommerce High-Performance Order Storage (HPOS).
+ *
+ * The plugin writes no order or order-item meta and reads orders only through
+ * the WooCommerce CRUD API, so it is HPOS-safe. Any future code that stores
+ * order data must use the CRUD API (never update_post_meta) to keep this true.
+ *
+ * @since SPSG_VERSION
+ */
+add_action(
+	'before_woocommerce_init',
+	function () {
+		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', STOREGROWTH_FILE, true );
+		}
 	}
 );
 


### PR DESCRIPTION
- Closes getdokan/storegrowth-sales-booster-pro#249

Two declaration defects, both cheap, both with real consequences.

## HPOS
Neither build declared compatibility with WooCommerce High-Performance Order Storage, so merchants saw the plugin listed as **incompatible** (and HPOS stores saw a warning) even though it is compatible today — it writes no order meta and reads orders only through `wc_get_orders()`.

- Declare `custom_order_tables` via `FeaturesUtil::declare_compatibility()` on `before_woocommerce_init` (guarded by `class_exists`).
- Documented in `CLAUDE.md` that order / order-item data must be written through the WooCommerce CRUD API, never `update_post_meta`, so the declaration stays honest.

## Version floor
`ModuleManager::get()` called **`array_find()`** — a PHP 8.4 function only polyfilled by WordPress core from 6.8 onward. On WordPress < 6.8 with PHP < 8.4, toggling any module was a **fatal error**, while `readme.txt` promised support back to 5.4.

**Preferred route taken:** replace the call with a plain `foreach` loop — no polyfill, runs on the declared PHP 7.4 floor — which removes the 6.8 dependency entirely and avoids stranding any of the install base.

- `ModuleManager::get()`: `array_find()` → `foreach`.
- Aligned the minimum WordPress version to **6.2** across the plugin header, `readme.txt` and `phpcs.xml`. 6.2 is the real technical floor: the settings UI uses `@wordpress/element` `createRoot` (React 18), first shipped in WP 6.2. (Confirmed no other WP-6.8-only function remains.)
- Declared a minimum WooCommerce version (`WC requires at least: 8.0`) in the header and readme, plus a **non-fatal** admin notice when WooCommerce is older than `Bootstrap::MIN_WC_VERSION`.

## Verification (runtime)
- `FeaturesUtil::get_compatible_plugins_for_feature('custom_order_tables')` now lists `storegrowth-sales-booster` (and the Pro build in its PR).
- `ModuleManager::get('bogo')` → module; `get('unknown')` → `null`; `is_active_module('bogo')` → `true` — with no `array_find()`.
- WC notice stays hidden on supported versions (tested on WC 11).

## Acceptance criteria
- ✅ Lite (and Pro, separate PR) declare `custom_order_tables` on `before_woocommerce_init`; listed as compatible with HPOS on/off.
- ✅ Doc note added about CRUD-API order writes.
- ✅ `array_find()` resolved via the preferred route (loop on the PHP floor).
- ✅ `storegrowth-sales-booster.php`, `readme.txt`, `phpcs.xml` all declare WP **6.2**.
- ✅ Minimum WooCommerce version declared + a version check (non-fatal notice).
- ⏳ CI: PHPCS already lints at the PHP 7.4 floor (`testVersion` 7.4-). A **follow-up** is needed to exercise an e2e job on 7.4 — the e2e dev dependencies cap at PHP < 8.0 (documented in `e2e.yml`), so that job needs its own dependency work rather than a one-line matrix add. Flagged rather than destabilize CI here.

## Non-regression
Module activation/deactivation and all ten module settings work on the floor (the `foreach` is behaviour-identical to `array_find` for the single-match lookup).

Pro companion PR: getdokan/storegrowth-sales-booster-pro (HPOS + header alignment).

> Cross-repo `Closes` links the pro issue but GitHub won't auto-close across repos; close #249 by hand on merge.