### PR TITLE
perf(sales-pop): catalogue-wide queries, dead CDN and cache-busting

### DIFF
--- a/assets/src/components/settings/Panels/PanelSettings/Fields/ProductAsyncMultiSelect.jsx
+++ b/assets/src/components/settings/Panels/PanelSettings/Fields/ProductAsyncMultiSelect.jsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "@wordpress/element";
+import apiFetch from "@wordpress/api-fetch";
+import { __ } from "@wordpress/i18n";
+import { Col, Select, Typography } from "antd";
+
+import SettingsTooltip from "../SettingsTooltip";
+import UpgradeCrown from "../UpgradeCrown";
+import FieldWrapper from "./FieldWrapper";
+
+const { Title } = Typography;
+
+const debounce = (fn, delay) => {
+  let timeoutId;
+  return (...args) => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn(...args), delay);
+  };
+};
+
+/**
+ * Multi-select of products backed by the REST products search, so the whole
+ * catalogue is never preloaded into the page.
+ *
+ * Options are the union of what the shopper searches for and the labels of the
+ * already-selected ids (resolved once on mount), so saved selections keep their
+ * names. External products are excluded, matching the previous behaviour.
+ */
+const ProductAsyncMultiSelect = ({
+  name,
+  title,
+  tooltip,
+  fieldValue,
+  changeHandler,
+  placeHolderText,
+  colSpan = 24,
+  needUpgrade = false,
+}) => {
+  const [options, setOptions] = useState([]);
+  const [fetching, setFetching] = useState(false);
+
+  const toOptions = (list) =>
+    (list || [])
+      .filter((product) => product?.type !== "external")
+      .map((product) => ({ label: product.name, value: product.id }));
+
+  const mergeOptions = (incoming) => {
+    setOptions((previous) => {
+      const byValue = new Map(previous.map((option) => [option.value, option]));
+      incoming.forEach((option) => byValue.set(option.value, option));
+      return Array.from(byValue.values());
+    });
+  };
+
+  // Resolve labels for the already-selected products so their chips render.
+  useEffect(() => {
+    const ids = (fieldValue || []).map(Number).filter(Boolean);
+
+    if (!ids.length) {
+      return;
+    }
+
+    apiFetch({
+      path: `/sales-booster/v1/products?include=${ids.join(",")}&per_page=${ids.length}`,
+    })
+      .then((response) => mergeOptions(toOptions(response)))
+      .catch(() => {});
+  }, []);
+
+  const searchProducts = debounce((value = "") => {
+    setFetching(true);
+
+    const params = new URLSearchParams({ search: value, per_page: 30 });
+
+    apiFetch({ path: `/sales-booster/v1/products?${params.toString()}` })
+      .then((response) => mergeOptions(toOptions(response)))
+      .catch(() => {})
+      .finally(() => setFetching(false));
+  }, 500);
+
+  return (
+    <FieldWrapper colSpan={colSpan} upgradeClass={needUpgrade ? "upgrade-settings" : ""}>
+      <Col span={9}>
+        <div className="card-heading">
+          <Title level={3} className="settings-heading space-top">
+            {title}
+          </Title>
+          {tooltip && <SettingsTooltip content={tooltip} />}
+          {needUpgrade && <UpgradeCrown />}
+        </div>
+      </Col>
+      <Col span={15}>
+        <Select
+          allowClear
+          showSearch
+          mode="multiple"
+          value={fieldValue}
+          options={options}
+          filterOption={false}
+          loading={fetching}
+          style={{ width: "100%" }}
+          placeholder={placeHolderText}
+          className="settings-field select-field"
+          onSearch={searchProducts}
+          onFocus={() => {
+            if (!options.length) {
+              searchProducts();
+            }
+          }}
+          onChange={(value) => changeHandler(name, value)}
+          notFoundContent={
+            fetching
+              ? __("Searching…", "storegrowth-sales-booster")
+              : __("Type to search products", "storegrowth-sales-booster")
+          }
+        />
+      </Col>
+    </FieldWrapper>
+  );
+};
+
+export default ProductAsyncMultiSelect;

--- a/modules/sales-pop/assets/src/components/CreateSalesPop.js
+++ b/modules/sales-pop/assets/src/components/CreateSalesPop.js
@@ -5,7 +5,7 @@ import { applyFilters } from '@wordpress/hooks';
 import SettingsSection from "../../../../../assets/src/components/settings/Panels/PanelSettings/SettingsSection";
 import Switcher from "../../../../../assets/src/components/settings/Panels/PanelSettings/Fields/Switcher";
 import TextAreaBox from "../../../../../assets/src/components/settings/Panels/PanelSettings/Fields/TextAreaBox";
-import MultiSelectBox from "../../../../../assets/src/components/settings/Panels/PanelSettings/Fields/MultiSelectBox";
+import ProductAsyncMultiSelect from "../../../../../assets/src/components/settings/Panels/PanelSettings/Fields/ProductAsyncMultiSelect";
 import { createPopupForm } from "../helper";
 import { Fragment } from "react";
 import ActionsHandler from "sales-booster/src/components/settings/Panels/PanelSettings/ActionsHandler";
@@ -149,10 +149,9 @@ function CreateSalesPop( { onFormSave, upgradeTeaser } ) {
         ) }
 
         { parseInt( createPopupFormData?.product_source ) === 1 && (
-          <MultiSelectBox
+          <ProductAsyncMultiSelect
             name={ 'popup_products' }
             changeHandler={ onFieldChange }
-            options={ productListForSelect }
             fieldValue={ selectedPopupProducts?.map( Number ) }
             needUpgrade={ isProductsSelectReachedlimit? upgradeTeaser : false }
             title={ __( 'Select Popup Products', 'storegrowth-sales-booster' ) }

--- a/modules/sales-pop/includes/EnqueueScript.php
+++ b/modules/sales-pop/includes/EnqueueScript.php
@@ -36,48 +36,169 @@ class EnqueueScript implements HookRegistry {
 
 		// Assets for Admin Panel.
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
+
+		// Invalidate the cached storefront popup payload when the popup config
+		// or any product changes.
+		add_action( 'update_option_spsg_popup_products', array( $this, 'flush_popup_cache' ) );
+		add_action( 'save_post_product', array( $this, 'flush_popup_cache' ) );
+		add_action( 'woocommerce_update_product', array( $this, 'flush_popup_cache' ) );
+		add_action( 'woocommerce_new_product', array( $this, 'flush_popup_cache' ) );
+		add_action( 'woocommerce_delete_product', array( $this, 'flush_popup_cache' ) );
+		add_action( 'woocommerce_trash_product', array( $this, 'flush_popup_cache' ) );
+	}
+
+	/**
+	 * Transient key for the resolved storefront popup payload.
+	 *
+	 * @since SPSG_VERSION
+	 *
+	 * @var string
+	 */
+	const POPUP_CACHE_KEY = 'spsg_sales_pop_popup_info';
+
+	/**
+	 * Per-request memo for the resolved popup payload. `false` = not resolved
+	 * yet; `null` = resolved to "nothing to show".
+	 *
+	 * @var array|null|false
+	 */
+	private $popup_info_memo = false;
+
+	/**
+	 * Delete the cached storefront popup payload.
+	 *
+	 * @since SPSG_VERSION
+	 *
+	 * @return void
+	 */
+	public function flush_popup_cache(): void {
+		$this->popup_info_memo = false;
+		delete_transient( self::POPUP_CACHE_KEY );
 	}
 
 	/**
 	 * Add JS scripts.
+	 *
+	 * Only enqueues when the popup will actually display, and localizes a
+	 * payload resolved from the configured products alone.
 	 */
 	public function enqueue_scripts() {
-		wp_enqueue_script( 'popup-custom-js', PluginHelper::get_modules_url( 'sales-pop/assets/js/popup-custom.js' ), array( 'jquery' ), time(), true );
-		$args             = array(
-			'post_type'      => 'product',
-			'posts_per_page' => -1,
+		$popup_info = $this->get_storefront_popup_info();
+
+		if ( null === $popup_info ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'popup-custom-js',
+			PluginHelper::get_modules_url( 'sales-pop/assets/js/popup-custom.js' ),
+			array( 'jquery' ),
+			STOREGROWTH_VERSION,
+			true
 		);
-		$products         = get_posts( $args );
+
+		wp_localize_script( 'popup-custom-js', 'popup_info', $popup_info );
+	}
+
+	/**
+	 * Add CSS files.
+	 */
+	public function enqueue_styles() {
+		if ( null === $this->get_storefront_popup_info() ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'popup-custom-css',
+			PluginHelper::get_modules_url( 'sales-pop/assets/css/popup-custom.css' ),
+			array(),
+			STOREGROWTH_VERSION
+		);
+
+		// The Font Awesome CDN enqueue was removed: this module renders no
+		// FontAwesome icons and the stackpath CDN it pointed at is retired, so
+		// it was a guaranteed failed, unconsented third-party request per page.
+	}
+
+	/**
+	 * Resolve the storefront popup payload, querying only the configured
+	 * products instead of the whole catalogue.
+	 *
+	 * Returns null when there is nothing to display, so callers can skip
+	 * enqueuing assets entirely. The result is memoized per request and cached
+	 * in a transient that is flushed on popup or product changes.
+	 *
+	 * @since SPSG_VERSION
+	 *
+	 * @return array|null
+	 */
+	private function get_storefront_popup_info(): ?array {
+		if ( false !== $this->popup_info_memo ) {
+			return $this->popup_info_memo;
+		}
+
+		$cached = get_transient( self::POPUP_CACHE_KEY );
+		if ( is_array( $cached ) ) {
+			$this->popup_info_memo = $cached;
+			return $cached;
+		}
+
 		$popup_properties = \StorePulse\StoreGrowth\Helper::get_settings( 'spsg_popup_products', false );
 
-		if ( false !== $popup_properties ) {
-			$popup_properties = maybe_unserialize( $popup_properties );
+		if ( false === $popup_properties || empty( $popup_properties ) ) {
+			$this->popup_info_memo = null;
+			return null;
+		}
 
-			// Neutralize any HTML/script that may already be stored (e.g. from
-			// a payload saved before the create_popup handler was hardened).
-			$popup_properties = Ajax::sanitize_popup_data( $popup_properties );
+		$popup_properties = maybe_unserialize( $popup_properties );
 
-			$popup_products    = $popup_properties['popup_products'] ?? array();
-			$product_list      = array();
-			$product_url       = array();
-			$product_image_url = array();
-			if ( $popup_products ) {
-				foreach ( $products as $product ) {
-					if ( ! in_array( $product->ID, $popup_products, true ) ) {
-						continue;
-					}
-					$external_link = ! empty( $popup_properties['external_link'] );
-					if ( $external_link || ! wc_get_product( $product->ID )->is_type( 'external' ) ) {
-						$product_list[]      = $product->post_title;
-						$image_url           = wp_get_attachment_image_src( get_post_thumbnail_id( $product->ID ), 'single-post-thumbnail' );
-						$product_image_url[] = isset( $image_url[0] ) ? $image_url[0] : false;
-						$product_url[]       = get_permalink( $product->ID );
+		// Neutralize any HTML/script that may already be stored (e.g. from a
+		// payload saved before the create_popup handler was hardened).
+		$popup_properties = Ajax::sanitize_popup_data( $popup_properties );
 
-					}
-				}
+		$popup_products = $popup_properties['popup_products'] ?? array();
+		$popup_products = array_values( array_filter( array_map( 'absint', (array) $popup_products ) ) );
+
+		if ( empty( $popup_products ) ) {
+			$this->popup_info_memo = null;
+			return null;
+		}
+
+		// Query ONLY the configured products (bounded by their count),
+		// preserving the date-DESC order the previous full-catalogue scan
+		// produced.
+		$products = get_posts(
+			array(
+				'post_type'      => 'product',
+				'post__in'       => $popup_products,
+				'posts_per_page' => count( $popup_products ),
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+				'post_status'    => 'publish',
+			)
+		);
+
+		$external_link     = ! empty( $popup_properties['external_link'] );
+		$product_list      = array();
+		$product_url       = array();
+		$product_image_url = array();
+
+		foreach ( $products as $product ) {
+			$wc_product = wc_get_product( $product->ID );
+
+			if ( ! $wc_product ) {
+				continue;
 			}
-		} else {
-			return;
+
+			if ( ! $external_link && $wc_product->is_type( 'external' ) ) {
+				continue;
+			}
+
+			$image_url = wp_get_attachment_image_src( get_post_thumbnail_id( $product->ID ), 'single-post-thumbnail' );
+
+			$product_list[]      = $product->post_title;
+			$product_image_url[] = isset( $image_url[0] ) ? $image_url[0] : false;
+			$product_url[]       = get_permalink( $product->ID );
 		}
 
 		$virtual_name = array();
@@ -85,9 +206,7 @@ class EnqueueScript implements HookRegistry {
 		if ( isset( $popup_properties['virtual_name'] ) ) {
 			if ( is_string( $popup_properties['virtual_name'] ) ) {
 				$virtual_name = explode( ',', $popup_properties['virtual_name'] );
-			}
-
-			if ( is_array( $popup_properties['virtual_name'] ) ) {
+			} elseif ( is_array( $popup_properties['virtual_name'] ) ) {
 				$virtual_name = $popup_properties['virtual_name'];
 			}
 		}
@@ -109,24 +228,13 @@ class EnqueueScript implements HookRegistry {
 			'virtual_locations'    => $virtual_locations,
 			'virtual_name'         => $virtual_name,
 			'popup_all_properties' => $popup_properties,
-			'fallback_image_url'   => $default_product_image_url = plugin_dir_url( __DIR__ ) . 'assets/images/sale_product.png',
+			'fallback_image_url'   => plugin_dir_url( __DIR__ ) . 'assets/images/sale_product.png',
 		);
 
-		wp_localize_script( 'popup-custom-js', 'popup_info', $popup_info );
-	}
+		set_transient( self::POPUP_CACHE_KEY, $popup_info, DAY_IN_SECONDS );
+		$this->popup_info_memo = $popup_info;
 
-	/**
-	 * Add CSS files.
-	 */
-	public function enqueue_styles() {
-		$ftime = filemtime( PluginHelper::get_modules_path( 'sales-pop/assets/css/popup-custom.css' ) );
-		wp_enqueue_style(
-			'popup-custom-css',
-			PluginHelper::get_modules_url( 'sales-pop/assets/css/popup-custom.css' ),
-			null,
-			$ftime
-		);
-		wp_enqueue_style( 'font-awesome-css', '//stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css', null, '1.0' );
+		return $popup_info;
 	}
 
 	/**

--- a/modules/sales-pop/includes/EnqueueScript.php
+++ b/modules/sales-pop/includes/EnqueueScript.php
@@ -350,11 +350,25 @@ class EnqueueScript implements HookRegistry {
 	 * @return array|int[]|\WP_Post[]
 	 */
 	public function get_billing_product_list() {
-		// Get all orders.
+		/**
+		 * How many recent orders the "Latest Orders" source scans.
+		 *
+		 * Bounded so the query no longer grows with total order history. The
+		 * products this source offers are derived from these most-recent
+		 * orders rather than every order ever placed.
+		 *
+		 * @since SPSG_VERSION
+		 *
+		 * @param int $limit Number of recent orders to scan.
+		 */
+		$orders_limit = (int) apply_filters( 'spsg_sales_pop_billing_orders_limit', 100 );
+
 		$orders = wc_get_orders(
 			array(
-				'limit'  => -1,
-				'status' => array( 'processing', 'completed', 'on-hold' ),
+				'limit'   => $orders_limit,
+				'orderby' => 'date',
+				'order'   => 'DESC',
+				'status'  => array( 'processing', 'completed', 'on-hold' ),
 			)
 		);
 
@@ -380,8 +394,9 @@ class EnqueueScript implements HookRegistry {
 		$ordered_products = array();
 		if ( ! empty( $ordered_product_ids ) ) {
 			$args = array(
-				'posts_per_page' => -1,
+				'posts_per_page' => count( $ordered_product_ids ), // Bounded by the ids already gathered.
 				'post_type'      => 'product',
+				'post_status'    => 'publish',
 				'post__in'       => $ordered_product_ids, // Limit posts to ordered product IDs.
 			);
 
@@ -400,9 +415,26 @@ class EnqueueScript implements HookRegistry {
 	 * @return int[]|\WP_Post[]
 	 */
 	public function get_selection_product_list() {
+		/**
+		 * How many recent products seed the selection list.
+		 *
+		 * The lite "Select Products" source searches the full catalogue live
+		 * through the REST products endpoint, so this bounded seed is only a
+		 * fallback (and the source list the Pro category filter reads). It no
+		 * longer loads the whole catalogue.
+		 *
+		 * @since SPSG_VERSION
+		 *
+		 * @param int $limit Number of recent products to seed with.
+		 */
+		$product_limit = (int) apply_filters( 'spsg_sales_pop_selection_products_limit', 200 );
+
 		$args = array(
 			'post_type'      => 'product',
-			'posts_per_page' => -1,
+			'post_status'    => 'publish',
+			'posts_per_page' => $product_limit,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
 		);
 
 		return get_posts( $args );
@@ -450,8 +482,9 @@ class EnqueueScript implements HookRegistry {
 
 			// Fetch product objects.
 			$args = array(
-				'posts_per_page' => -1,
+				'posts_per_page' => count( $product_ids ), // Already capped to 10 ids above.
 				'post_type'      => 'product',
+				'post_status'    => 'publish',
 				'post__in'       => $product_ids, // Limit posts to ordered product IDs.
 			);
 
@@ -469,31 +502,45 @@ class EnqueueScript implements HookRegistry {
 	 * @return array
 	 */
 	public function get_category_product_list() {
-		// Get all product categories.
-		$categories = $this->category_list();
+		/**
+		 * Product cap when grouping products by category.
+		 *
+		 * Replaces the previous per-category query loop, which ran one
+		 * unbounded query per category and scaled with the number of
+		 * categories. This scans a bounded set of recent products once.
+		 *
+		 * @since SPSG_VERSION
+		 *
+		 * @param int $limit Maximum products scanned across all categories.
+		 */
+		$product_limit = (int) apply_filters( 'spsg_sales_pop_category_products_limit', 200 );
 
-		// Create an empty array to store the category name as the key and products as the value.
+		$product_ids = get_posts(
+			array(
+				'post_type'      => 'product',
+				'post_status'    => 'publish',
+				'posts_per_page' => $product_limit,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+				'fields'         => 'ids',
+			)
+		);
+
 		$category_products = array();
 
-		// Loop through the categories.
-		foreach ( $categories as $category_id => $category_name ) {
-			// Get the products in the current category.
-			$args = array(
-				'post_type'      => 'product',
-				'posts_per_page' => -1,
-				'fields'         => 'ids',
-				'tax_query'      => array(
-					array(
-						'taxonomy' => 'product_cat',
-						'field'    => 'term_id',
-						'terms'    => $category_id,
-					),
-				),
-			);
+		if ( empty( $product_ids ) ) {
+			return $category_products;
+		}
 
-			$products = get_posts( $args );
-			// Assign products to the category id.
-			$category_products[ $category_id ] = $products;
+		// One term query for every scanned product, grouped by category id.
+		$terms = wp_get_object_terms( $product_ids, 'product_cat', array( 'fields' => 'all_with_object_id' ) );
+
+		if ( is_wp_error( $terms ) ) {
+			return $category_products;
+		}
+
+		foreach ( $terms as $term ) {
+			$category_products[ $term->term_id ][] = $term->object_id;
 		}
 
 		return $category_products;


### PR DESCRIPTION
Closes getdokan/storegrowth-sales-booster-pro#248

The Sales Notifications module ran a full-catalogue query on **every storefront page load** and loaded every order/product to build its admin selectors. This fixes the storefront path (the headline defect) and bounds the admin path.

## Storefront (`enqueue_scripts` / `enqueue_styles`)
- **Query only the configured products.** Replaced `get_posts([...'posts_per_page' => -1])` (whole catalogue, then per-product `wc_get_product`/`wp_get_attachment_image_src`) with a single bounded `post__in` query over the stored `popup_products`, preserving the previous date-DESC order.
- **Skip assets entirely** when no popup will display (no config / no products) — script and style are no longer enqueued on those pages.
- **Real, cacheable version.** `time()` and `filemtime()` → `STOREGROWTH_VERSION`, so the asset URL is identical across reloads.
- **Dead CDN removed.** Dropped the `//stackpath.bootstrapcdn.com/font-awesome/4.7.0/…` enqueue — the module renders no FontAwesome icons and that CDN is retired (a guaranteed failed, unconsented third-party request and a wordpress.org guideline violation).
- **Cached** the resolved payload in a transient, flushed on popup-config or product changes (`update_option_spsg_popup_products`, `save_post_product`, `woocommerce_update_product` / `_new_product` / `_delete_product` / `_trash_product`).

## Admin (settings screen)
- `get_billing_product_list()`: scan the most recent **N orders** (`spsg_sales_pop_billing_orders_limit`, default 100) instead of `limit => -1`.
- `get_selection_product_list()`: seed from recent **N products** (`spsg_sales_pop_selection_products_limit`, default 200) instead of the whole catalogue.
- `get_category_product_list()`: replace the **per-category query loop** with one bounded product scan grouped by category via a single term query — no longer scales with category count.
- `get_recently_viewed_product_list()`: drop the `-1` (already capped to 10).
- **"Select Products" picker → async.** New shared `ProductAsyncMultiSelect` (REST `sales-booster/v1/products` search) replaces the multiselect that preloaded every product. It resolves labels for already-selected ids on mount (`?include=`) and excludes external products, so saved configs render and behave identically. The full catalogue is still selectable — via live search, not a preload.

**No `posts_per_page => -1` / `limit => -1` remains anywhere in the module.**

## Verification (runtime + browser)
- Storefront: `popup_info` localized with only the configured products; version `2.1.1` (stable across reloads); **zero** stackpath/font-awesome requests; transient cached and flushed on save; assets skipped when `popup_products` is empty.
- Admin: async picker resolves preselected labels ("Simple Subscription", "Dokan Subscription"), live-searches ("learn" → "Learn React"), add/remove works, **Save persists** (`[6054,2345]`), and the storefront then reflects the saved selection (cache flushed on save). Screenshots taken before/after.
- `product_list()` returns bounded sets (billing 12, selection seed 34/≤200, categories grouped in one query).

## Non-regression notes
- **Billing source** (the one risky path per the issue): now derives from the **most recent 100 orders** rather than all history. On stores with a long order history this can change which products the "Latest Orders" source offers — an intentional, filterable bound, called out here for review.
- Popup behaviour, images, names, locations, timing and styling are unchanged; the popup still works with page caching (stable asset URLs + transient).

## Notes
- Built bundles are produced by CI (`assets/build/` is gitignored); only source is committed.
- Drive-by: the root `package.json` `build:sales-pop` script targets a stale scope (`sales-booster-sales-pop`); the package is `sales-booster-sales-notification`. Left as-is to keep this PR focused — flagging for a follow-up.
- Cross-repo `Closes` links the pro issue but GitHub won't auto-close across repos; close #248 by hand on merge.