### PR TITLE
fix: unauthenticated cart price manipulation via public AJAX (BOGO & Order Bump)

### DIFF
--- a/modules/bogo/includes/Ajax.php
+++ b/modules/bogo/includes/Ajax.php
@@ -56,11 +56,18 @@ class Ajax implements HookRegistry {
 		$item_key            = isset( $data['cart_item_key'] ) ? intval( $data['cart_item_key'] ) : 0;
 		$main_product_id     = isset( $data['main_product_id'] ) ? intval( $data['main_product_id'] ) : 0;
 		$product_link_key    = isset( $data['product_link_key'] ) ? esc_html( $data['product_link_key'] ) : '';
-		$offer_product_cost  = isset( $data['offer_product_cost'] ) ? floatval( $data['offer_product_cost'] ) : 0;
 		$selected_product_id = isset( $data['selected_product_id'] ) ? intval( $data['selected_product_id'] ) : 0;
 
 		if ( ! $selected_product_id || ! $main_product_id ) {
 			wp_send_json_error( 'Invalid product ID.' );
+		}
+
+		// The gift price is derived from the offer configuration server-side; any
+		// client-sent `offer_product_cost` is ignored. Authorise the swap before
+		// touching the cart so a rejected request leaves the current gift intact.
+		$offer_product_cost = $this->resolve_authorized_bogo_price( $selected_product_id );
+		if ( null === $offer_product_cost ) {
+			wp_send_json_error( __( 'This gift is not available for your cart.', 'storegrowth-sales-booster' ), 403 );
 		}
 
 		// Logic to remove the existing offer product and add the new one.
@@ -136,6 +143,15 @@ class Ajax implements HookRegistry {
 
 			if ( ! $variation_id ) {
 				wp_send_json_error( __( 'No available variation found for this product.', 'storegrowth-sales-booster' ) );
+			}
+		}
+
+		// Refine the derived price for the resolved variation (variation prices
+		// differ from the parent). Authorisation already passed above.
+		if ( $variation_id ) {
+			$variation_price = $this->resolve_authorized_bogo_price( $selected_product_id, $variation_id );
+			if ( null !== $variation_price ) {
+				$offer_product_cost = $variation_price;
 			}
 		}
 
@@ -261,49 +277,114 @@ class Ajax implements HookRegistry {
 
 	/**
 	 * Bogo product add to cart.
+	 *
+	 * The reward price is derived server-side from the offer configuration; any
+	 * `bogo_price` in the request is ignored. The request is rejected — nothing
+	 * added — unless an active offer the current cart qualifies for authorises
+	 * this product as its reward.
 	 */
 	public function offer_product_add_to_cart() {
 		check_ajax_referer( 'spsg_frontend_ajax_nonce' );
 
 		global $woocommerce;
-		$all_cart_products = $woocommerce->cart->get_cart();
 
-		foreach ( $all_cart_products as $value ) {
-			$cat_ids = $value['data']->get_category_ids();
-			foreach ( $cat_ids as $cat_id ) {
-				$all_cart_category_ids[] = $cat_id;
-			}
-			$all_cart_product_ids[] = $value['product_id'];
-		}
-
-		$bogo_price       = isset( $_POST['data']['bogo_price'] ) ? floatval( wp_unslash( $_POST['data']['bogo_price'] ) ) : null;
 		$checked          = isset( $_POST['data']['checked'] ) ? boolval( wp_unslash( $_POST['data']['checked'] ) ) : null;
 		$offer_product_id = isset( $_POST['data']['offer_product_id'] ) ? intval( wp_unslash( $_POST['data']['offer_product_id'] ) ) : null;
 
 		if ( $checked ) {
-			$product_id      = $offer_product_id;
-			$product_cart_id = WC()->cart->generate_cart_id( $product_id );
-			$cart_item_key   = WC()->cart->find_product_in_cart( $product_cart_id );
 			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 				if ( $cart_item['product_id'] === $offer_product_id ) {
 					WC()->cart->remove_cart_item( $cart_item_key );
 				}
 			}
-		} else {
-			$custom_price = $bogo_price;
-			// Cart item data to send & save in order.
-			$cart_item_data = array( 'custom_price' => $custom_price );
-			// Woocommerce function to add product into cart check its documentation also.
-			$woocommerce->cart->add_to_cart( $offer_product_id, 1, $variation_id = 0, $variation = array(), $cart_item_data );
-			// Calculate totals.
-			$woocommerce->cart->calculate_totals();
-			// Save cart to session.
-			$woocommerce->cart->set_session();
-			// Maybe set cart cookies.
-			$woocommerce->cart->maybe_set_cart_cookies();
 
+			die();
 		}
 
+		if ( ! $offer_product_id ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid product.', 'storegrowth-sales-booster' ) ), 400 );
+		}
+
+		$offer_price = $this->resolve_authorized_bogo_price( $offer_product_id );
+		if ( null === $offer_price ) {
+			wp_send_json_error( array( 'message' => __( 'This offer is not available.', 'storegrowth-sales-booster' ) ), 403 );
+		}
+
+		// Use the BOGO price key so OrderBogo prices the gift — never
+		// `custom_price`, which is the Upsell Order Bump key and left the gift
+		// full-priced whenever that module was inactive.
+		$cart_item_data = array( 'bogo_offer_price' => $offer_price );
+		$woocommerce->cart->add_to_cart( $offer_product_id, 1, 0, array(), $cart_item_data );
+		$woocommerce->cart->calculate_totals();
+		$woocommerce->cart->set_session();
+		$woocommerce->cart->maybe_set_cart_cookies();
+
 		die();
+	}
+
+	/**
+	 * Resolve the price a BOGO reward may be added at, deriving it from the
+	 * offer configuration instead of trusting the client.
+	 *
+	 * Returns null when no active offer that the current cart qualifies for
+	 * authorises adding this product as its reward, so callers add nothing.
+	 *
+	 * @since SPSG_VERSION
+	 *
+	 * @param int $offer_product_id Requested reward product id (parent id for a
+	 *                              variable gift).
+	 * @param int $variation_id     Resolved variation id, if any.
+	 *
+	 * @return float|null Authorised price, or null when unauthorised.
+	 */
+	private function resolve_authorized_bogo_price( int $offer_product_id, int $variation_id = 0 ) {
+		if ( ! function_exists( 'WC' ) || ! WC()->cart ) {
+			return null;
+		}
+
+		$price_product = wc_get_product( $variation_id ? $variation_id : $offer_product_id );
+		if ( ! $price_product ) {
+			return null;
+		}
+
+		foreach ( WC()->cart->get_cart() as $cart_item ) {
+			$trigger_product_id = (int) $cart_item['product_id'];
+
+			$settings = BogoValidator::get_product_bogo_settings( $trigger_product_id );
+			if ( empty( $settings ) ) {
+				continue;
+			}
+
+			$trigger_category_ids = $cart_item['data'] instanceof \WC_Product ? $cart_item['data']->get_category_ids() : array();
+			if ( ! BogoValidator::should_display_offer( $settings, $trigger_product_id, $trigger_category_ids ) ) {
+				continue;
+			}
+
+			// The trigger must meet the offer's minimum quantity condition.
+			$min_qty = max( 1, intval( $settings['minimum_quantity_required'] ?? 1 ) );
+			if ( (int) $cart_item['quantity'] < $min_qty ) {
+				continue;
+			}
+
+			// The requested product must be this offer's configured reward or one
+			// of its configured alternates.
+			$reward_id  = (int) BogoValidator::get_offer_product_id( $settings, $trigger_product_id );
+			$alternates = $settings['alternate_products'] ?? $settings['get_alternate_products'] ?? array();
+			$authorized = array_map( 'intval', array_merge( array( $reward_id ), (array) $alternates ) );
+
+			if ( ! in_array( (int) $offer_product_id, $authorized, true ) ) {
+				continue;
+			}
+
+			// Price derived from the offer, matching OrderBogo::apply_bogo_product()
+			// and OrderBogo.php:531 exactly (filtered product price).
+			if ( isset( $settings['offer_type'] ) && 'discount' === $settings['offer_type'] ) {
+				return (float) max( $price_product->get_price() - ( $price_product->get_price() * ( $settings['discount_amount'] / 100 ) ), 0 );
+			}
+
+			return 0.0; // Free offer.
+		}
+
+		return null;
 	}
 }

--- a/modules/upsell-order-bump/includes/OrderBumpAjax.php
+++ b/modules/upsell-order-bump/includes/OrderBumpAjax.php
@@ -8,6 +8,7 @@
 namespace StorePulse\StoreGrowth\Modules\UpsellOrderBump;
 
 use StorePulse\StoreGrowth\Interfaces\HookRegistry;
+use StorePulse\StoreGrowth\Modules\UpsellOrderBump\Database\OrderBumpData;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -32,47 +33,112 @@ class OrderBumpAjax implements HookRegistry {
 	 */
 	public function upsell_offer_product_add_to_cart() {
 		check_ajax_referer( 'spsg_frontend_ajax_nonce' );
-		
+
 		global $woocommerce;
-		$all_cart_products = $woocommerce->cart->get_cart();
 
-		foreach ( $all_cart_products as $value ) {
-			$cat_ids = $value['data']->get_category_ids();
-			foreach ( $cat_ids as $cat_id ) {
-				$all_cart_category_ids[] = $cat_id;
-			}
-			$all_cart_product_ids[] = $value['product_id'];
-		}
-
-		$bump_price         = isset( $_POST['data']['bump_price'] ) ? floatval( wp_unslash( $_POST['data']['bump_price'] ) ) : null;
 		$checked            = isset( $_POST['data']['checked'] ) ? boolval( wp_unslash( $_POST['data']['checked'] ) ) : null;
 		$offer_product_id   = isset( $_POST['data']['offer_product_id'] ) ? intval( wp_unslash( $_POST['data']['offer_product_id'] ) ) : null;
 		$offer_variation_id = isset( $_POST['data']['offer_variation_id'] ) ? intval( wp_unslash( $_POST['data']['offer_variation_id'] ) ) : null;
-		
+
+		// Any `bump_price` in the request is ignored; the price is derived
+		// server-side from the bump configuration.
+
 		if ( $checked ) {
-			$product_id      = $offer_product_id;
-			$product_cart_id = WC()->cart->generate_cart_id( $product_id );
-			$cart_item_key   = WC()->cart->find_product_in_cart( $product_cart_id );
 			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 				if ( $cart_item['product_id'] === $offer_product_id ) {
 					WC()->cart->remove_cart_item( $cart_item_key );
 				}
 			}
-		} else {
-			$custom_price = $bump_price;
-			// Cart item data to send & save in order.
-			$cart_item_data = array( 'custom_price' => $custom_price, '_spsg_order_bump_product' => true );
-			// Woocommerce function to add product into cart check its documentation also.
-			$woocommerce->cart->add_to_cart( $offer_product_id, 1, $offer_variation_id, $variation = array(), $cart_item_data );
-			// Calculate totals.
-			$woocommerce->cart->calculate_totals();
-			// Save cart to session.
-			$woocommerce->cart->set_session();
-			// Maybe set cart cookies.
-			$woocommerce->cart->maybe_set_cart_cookies();
+
+			wp_send_json_success( $offer_variation_id );
 		}
+
+		if ( ! $offer_product_id ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid product.', 'storegrowth-sales-booster' ) ), 400 );
+		}
+
+		$bump_price = $this->resolve_authorized_bump_price( $offer_product_id );
+		if ( null === $bump_price ) {
+			wp_send_json_error( array( 'message' => __( 'This offer is not available.', 'storegrowth-sales-booster' ) ), 403 );
+		}
+
+		// `custom_price` is the Order Bump price key applied by
+		// OrderBump::woocommerce_custom_price_to_cart_item().
+		$cart_item_data = array(
+			'custom_price'             => $bump_price,
+			'_spsg_order_bump_product' => true,
+		);
+		$woocommerce->cart->add_to_cart( $offer_product_id, 1, $offer_variation_id, array(), $cart_item_data );
+		$woocommerce->cart->calculate_totals();
+		$woocommerce->cart->set_session();
+		$woocommerce->cart->maybe_set_cart_cookies();
 
 		wp_send_json_success( $offer_variation_id );
 		die();
+	}
+
+	/**
+	 * Resolve the price an order-bump product may be added at, deriving it from
+	 * the bump configuration instead of trusting the client.
+	 *
+	 * Returns null when no bump the current cart qualifies for offers this
+	 * product, so callers add nothing.
+	 *
+	 * @since SPSG_VERSION
+	 *
+	 * @param int $offer_product_id Requested bump product id.
+	 *
+	 * @return float|null Authorised price, or null when unauthorised.
+	 */
+	private function resolve_authorized_bump_price( int $offer_product_id ) {
+		if ( ! function_exists( 'WC' ) || ! WC()->cart ) {
+			return null;
+		}
+
+		$cart_product_ids  = array();
+		$cart_category_ids = array();
+
+		foreach ( WC()->cart->get_cart() as $cart_item ) {
+			$cart_product_ids[] = (int) $cart_item['product_id'];
+
+			if ( isset( $cart_item['variation_id'] ) && $cart_item['variation_id'] > 0 ) {
+				$cart_product_ids[] = (int) $cart_item['variation_id'];
+			}
+
+			if ( $cart_item['data'] instanceof \WC_Product ) {
+				foreach ( $cart_item['data']->get_category_ids() as $cat_id ) {
+					$cart_category_ids[] = (int) $cat_id;
+				}
+			}
+		}
+
+		$cart_category_ids = array_unique( $cart_category_ids );
+
+		$order_bump_data = new OrderBumpData();
+		$matching_bumps  = $order_bump_data->get_matching_bumps( $cart_product_ids, $cart_category_ids );
+
+		foreach ( $matching_bumps as $bump ) {
+			if ( (int) $bump['offer_product_id'] !== (int) $offer_product_id ) {
+				continue;
+			}
+
+			$product = wc_get_product( $offer_product_id );
+			if ( ! $product ) {
+				return null;
+			}
+
+			// Price derived from the bump, matching
+			// OrderBump::bump_product_frontend_view() exactly.
+			$regular_price = $product->get_regular_price();
+			$current_price = $product->get_sale_price() ? $product->get_sale_price() : $regular_price;
+
+			if ( 'discount' === $bump['offer_type'] ) {
+				return (float) ( $current_price - ( $current_price * $bump['offer_amount'] / 100 ) );
+			}
+
+			return (float) $bump['offer_amount'];
+		}
+
+		return null;
 	}
 }


### PR DESCRIPTION
- Closes getdokan/storegrowth-sales-booster-pro#243

**Security — critical.** Three public `nopriv` AJAX endpoints accepted a cart-line price from the client and applied it to the cart. Their only guard, `spsg_frontend_ajax_nonce` (`ajd_protected`), is printed into every storefront page for anonymous visitors, so it authorises nothing. Any visitor could add any product at any price — including 0 — and complete checkout.

## Fix — server-side price derivation
The three handlers no longer read a price from the request:

| handler | file | was |
|---|---|---|
| `offer_product_add_to_cart` | `modules/bogo/includes/Ajax.php` | `$_POST['data']['bogo_price']` |
| `handle_update_offer_product` | `modules/bogo/includes/Ajax.php` | `offer_product_cost` |
| `upsell_offer_product_add_to_cart` | `modules/upsell-order-bump/includes/OrderBumpAjax.php` | `bump_price` |

For each request the server resolves the offer/bump the current cart qualifies for, confirms the requested product is that offer's configured reward or `alternate_products` entry (or the bump's product), and **derives the price from the configuration**. Any price field still sent by a cached page is ignored, not an error (kept for one release per the front-end contract).

**Rejected — nothing added — when:** no active matching offer, out of date range/schedule, cart lacks the trigger product/category, minimum quantity not met, or the product is not a configured reward.

**Formulas reused exactly (byte-identical pricing):**
- BOGO free = `0`; discount = `price − price·(discount_amount/100)` (`OrderBogo.php:531`).
- Bump discount = `price − price·(offer_amount/100)`; else flat `offer_amount` (`OrderBump`).

## Cart-item-key fix
`offer_product_add_to_cart` now writes **`bogo_offer_price`**, not `custom_price`. `custom_price` is the Upsell Order Bump price key, so a BOGO gift added that way was priced by the bump module and charged at **full price when that module was deactivated**. `bogo_offer_price` is applied by `OrderBogo::woocommerce_custom_price_to_cart_item()` independently.

## Verification (runtime, real offers on a dev store)
Reflection on the private resolvers against configured offers:

| case | result |
|---|---|
| free BOGO (buy 120 → gift 91) | `0.0` ✅ |
| 25% discount BOGO (product price 18) | `13.5` == formula ✅ |
| 2% order bump (product price 18) | `17.64` == formula ✅ |
| product that is not the reward | `null` → rejected ✅ |
| trigger not in cart / empty cart | `null` → rejected ✅ |

The resolvers take only a product id — no price can enter from the request.

## Non-regression
- **Nonce/contract:** `spsg_frontend_ajax_nonce` remains for CSRF only; the browser may still send a price field for one release, ignored server-side, so pages cached before the update keep working.
- **Gutenberg block** (`OrderBumpCheckoutIntegration.php`): already computes the bump price server-side with the same formula for display, and has no add-to-cart of its own — acceptance routes through the fixed ajax handler, so it prices identically.
- **Dokan vendor BOGO:** offers resolve through the same `BogoValidator` path (which honours the `spsg_is_bogo_applicable_product` / `spsg_bogo_check_permission` filters the Dokan integration hooks), so a vendor-owned offer applies unchanged on the storefront.

> Security release: coordinate changelog wording and the wordpress.org SVN deploy timing with security comms before publishing. Merging this PR does not publish; the SVN deploy is a separate step.
> Cross-repo `Closes` links the pro issue but GitHub won't auto-close across repos; close #243 by hand on merge.