### PR TITLE
fix: stored-XSS output escaping (Sales Notifications & BOGO)

### DIFF
--- a/modules/bogo/includes/Ajax.php
+++ b/modules/bogo/includes/Ajax.php
@@ -222,6 +222,17 @@ class Ajax implements HookRegistry {
 			$data['editableId'] = absint( $data['editableId'] );
 		}
 
+		/**
+		 * Maximum number of stored BOGO category messages.
+		 *
+		 * Caps the option so it cannot be grown without bound.
+		 *
+		 * @since SPSG_VERSION
+		 *
+		 * @param int $max Maximum category messages.
+		 */
+		$max_messages = (int) apply_filters( 'spsg_bogo_max_category_messages', 100 );
+
 		if ( ! empty( $data['editableId'] ) && in_array( $data['editableId'], $cat_ids, true ) ) {
 			$index = array_search( $data['editableId'], $cat_ids, true );
 
@@ -229,6 +240,17 @@ class Ajax implements HookRegistry {
             $bogo_settings['bogo_category_messages'][ $index ]['message']        = $data['message'];
             $bogo_settings['bogo_category_messages'][ $index ]['categoryStatus'] = $data['categoryStatus'];
         } else {
+            if ( count( $cat_ids ) >= $max_messages ) {
+                wp_send_json_error(
+                    sprintf(
+                        /* translators: %d: maximum number of category messages. */
+                        __( 'You can store at most %d category messages.', 'storegrowth-sales-booster' ),
+                        $max_messages
+                    ),
+                    400
+                );
+            }
+
             $bogo_settings['bogo_category_messages'][] = $data;
         }
 

--- a/modules/bogo/templates/bogo-offer-products-popup.php
+++ b/modules/bogo/templates/bogo-offer-products-popup.php
@@ -47,7 +47,7 @@ if ( ! empty( $offer_products ) ) : ?>
 						<li>
 							<div class="alternate-product-container">
 							<img src="<?php echo esc_url( $image_url[0] ); ?>" alt="product">
-							<div class="altenate-product-heading"><h3><?php echo $product->get_title(); ?></h3>
+							<div class="altenate-product-heading"><h3><?php echo esc_html( $product->get_title() ); ?></h3>
 							<span class="choosen-offer-product"
 								data-product-id="<?php echo esc_attr( $product->get_id() ); ?>"
                                 data-item-key="<?php echo esc_attr( $cart_item['parent_key'] ); ?>"

--- a/modules/floating-notification-bar/includes/EnqueueScript.php
+++ b/modules/floating-notification-bar/includes/EnqueueScript.php
@@ -122,6 +122,23 @@ class EnqueueScript implements HookRegistry {
 	}
 
 	/**
+	 * Constrain a stored colour value to characters valid in a CSS colour.
+	 *
+	 * Keeps hex, `rgb()/rgba()`, `hsl()`, named colours and percentages while
+	 * stripping quotes, braces, semicolons and angle brackets, so a stored
+	 * value can never break out of the CSS rule it is interpolated into.
+	 *
+	 * @since SPSG_VERSION
+	 *
+	 * @param mixed $value Stored colour value.
+	 *
+	 * @return string
+	 */
+	private function sanitize_css_color( $value ): string {
+		return preg_replace( '/[^a-zA-Z0-9#(),.%\s-]/', '', (string) $value );
+	}
+
+	/**
 	 * All inline styles
 	 */
 	private function inline_styles() {
@@ -147,19 +164,21 @@ class EnqueueScript implements HookRegistry {
 				'label' => 'IBM Plex Sans',
 			),
 		);
-		// Get style options.
+		// Get style options. Each value is interpolated into a <style> block,
+		// so colours are constrained to safe CSS colour characters and sizes to
+		// integers — a stored value can never break out of the CSS context.
 		$settings          = Helper::get_settings();
-		$bar_position      = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'bar_position', 'top' );
-		$bar_type          = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'bar_type', 'normal' );
-		$bg_color          = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'background_color', '#008DFF' );
-		$text_color        = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'text_color', '#ffffff' );
-		$icon_color        = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'icon_color', '#ffffff' );
-		$close_icon_color  = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'close_icon_color', '#ffffff' );
-		$banner_height     = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'banner_height', 60 );
-		$font_size         = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'font_size', 20 );
-		$button_color      = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'button_color', '#ffffff' );
-		$button_text_color = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'button_text_color', '#ffffff' );
-		$font_family       = \StorePulse\StoreGrowth\Helper::find_option_settings( $settings, 'font_family', 'poppins' );
+		$bar_position      = PluginHelper::find_option_settings( $settings, 'bar_position', 'top' );
+		$bar_type          = PluginHelper::find_option_settings( $settings, 'bar_type', 'normal' );
+		$bg_color          = $this->sanitize_css_color( PluginHelper::find_option_settings( $settings, 'background_color', '#008DFF' ) );
+		$text_color        = $this->sanitize_css_color( PluginHelper::find_option_settings( $settings, 'text_color', '#ffffff' ) );
+		$icon_color        = $this->sanitize_css_color( PluginHelper::find_option_settings( $settings, 'icon_color', '#ffffff' ) );
+		$close_icon_color  = $this->sanitize_css_color( PluginHelper::find_option_settings( $settings, 'close_icon_color', '#ffffff' ) );
+		$banner_height     = absint( PluginHelper::find_option_settings( $settings, 'banner_height', 60 ) );
+		$font_size         = absint( PluginHelper::find_option_settings( $settings, 'font_size', 20 ) );
+		$button_color      = $this->sanitize_css_color( PluginHelper::find_option_settings( $settings, 'button_color', '#ffffff' ) );
+		$button_text_color = $this->sanitize_css_color( PluginHelper::find_option_settings( $settings, 'button_text_color', '#ffffff' ) );
+		$font_family       = PluginHelper::find_option_settings( $settings, 'font_family', 'poppins' );
 		$selected_font     = $this->get_label_by_value( $font_family, $font_family_arr );
 
 		if ( 'bottom' === $bar_position ) {

--- a/modules/sales-pop/templates/popup.php
+++ b/modules/sales-pop/templates/popup.php
@@ -20,10 +20,12 @@ $image_without_link = '<img id="image_of_product" src="#"
 
 			<div class="custom-notification-image-wrapper" style="padding:<?php echo isset( $image_spacing ) ? esc_attr( $image_spacing ) : null; ?>px">
 				<?php
+				// Product image markup (an <img>, optionally wrapped in an <a>).
+				// wp_kses_post keeps that markup while stripping scripts/handlers.
 				if ( $popup_properties['link_image_to_product'] ) {
-                    echo $image_with_link; //phpcs:ignore
+					echo wp_kses_post( $image_with_link );
 				} else {
-                    echo $image_without_link; //phpcs:ignore
+					echo wp_kses_post( $image_without_link );
 				}
 				?>
 			</div>


### PR DESCRIPTION
- Closes getdokan/storegrowth-sales-booster-pro#244

## Already in place (2.1.1)
The critical part of #244 — the *unauthenticated* write — is already closed:
- `create_popup`, `bogo_category_msg_create`, `popup_products` are registered on `wp_ajax_*` only (no `wp_ajax_nopriv_`), guarded by the admin nonce `spsg_admin_ajax_nonce`, and check `current_user_can( 'manage_options' )`.
- Popup config is sanitised on write and again before storefront localize by `Ajax::sanitize_popup_data()` (recursive; strips all HTML via `sanitize_textarea_field`; id-lists cast with `absint`), so markup stored before the fix is neutralised on render.
- `popup-custom.js` already documents why its single `.html()` is safe (message is server-sanitised plain text; the `{product_title}`/`{location}`/… fragments are injected with jQuery `.text()`).

## This PR — the remaining output-escaping + growth cap
- **`bogo-offer-products-popup.php`** — escape the product title with `esc_html()`.
- **`popup.php`** — render the product image markup with `wp_kses_post()` and remove the `phpcs:ignore` on the raw echoes (keeps `<img>`/`<a>`, strips scripts/handlers).
- **`floating-notification-bar/EnqueueScript.php`** — constrain every colour option to safe CSS colour characters (new `sanitize_css_color()`) and cast sizes with `absint()` before interpolating them into the inline `<style>` block, so a stored value can't break out of the CSS context. Also switched the fully-qualified `\StorePulse\StoreGrowth\Helper::` calls to the existing `PluginHelper` import.
- **`bogo/includes/Ajax.php`** — cap `bogo_category_messages` at a documented, filterable maximum (`spsg_bogo_max_category_messages`, default 100).

## Verification
- `sanitize_css_color`: keeps `#008DFF`, `rgba(0,0,0,0.5)`, `red`; strips `;`, `}`, `<`, `>`, `/` from `#fff;}</style><script>alert(1)</script>` → contained CSS value, no break-out.
- Storefront (`/shop/`): HTTP 200, no fatal, inline CSS renders with escaped colours.
- Cap: 100 existing → the next create is rejected (400); 5 existing → allowed.

## Existing-data note
No migration is required for the popup option — `sanitize_popup_data()` already runs before the value is localized, so any markup injected before this release is stripped on render, not left in place. The change only strips markup that was never intended to be configurable; merchant plain-text/allowed-image content is unaffected.

> Ship in the same security release as the price-manipulation fix (#243).
> Cross-repo `Closes` links the pro issue but GitHub won't auto-close across repos; close #244 by hand on merge.