### PR TITLE
fix: register CommonServiceProvider eagerly so its REST routes exist on PHP < 8.1

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,13 @@ name: E2E & API Tests
 # pushes to the long-lived branches, on published releases, and on demand.
 # Make "E2E Tests" a required status check in branch protection so a PR can
 # only merge once this whole workflow is green.
+#
+# The PHP version the site under test runs on defaults to 7.4 — the floor the
+# plugin actually claims (`composer.json` "php": ">=7.4", `Requires PHP: 7.4`).
+# Testing the floor is what catches bugs that only surface below 8.1, such as
+# static variables in inherited methods becoming shared with the parent scope
+# in 8.1; an 8.2-only matrix is blind to them. A manual run can pick any other
+# supported version.
 on:
   pull_request:
   push:
@@ -11,6 +18,14 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      php_version:
+        description: 'PHP version for the site under test'
+        type: choice
+        default: '7.4'
+        options: ['7.4', '8.0', '8.1', '8.2', '8.3']
+
+run-name: E2E & API Tests (PHP ${{ github.event.inputs.php_version || '7.4' }})
 
 # Cancel superseded runs on the same ref/PR to save CI minutes.
 concurrency:
@@ -162,7 +177,7 @@ jobs:
           if-no-files-found: error
 
   playwright:
-    name: Playwright (${{ matrix.name }})
+    name: Playwright (${{ matrix.name }} · PHP ${{ github.event.inputs.php_version || '7.4' }})
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 25
@@ -238,20 +253,26 @@ jobs:
               -C storegrowth-sales-booster-pro
           fi
 
-      # Map the prebuilt Pro into the wp-env site (.wp-env.override.json is
-      # deep-merged over .wp-env.json). provision-site.php activates the plugin
-      # + license later.
-      - name: Map Pro into wp-env
-        if: ${{ needs.build.outputs.has-pro == 'true' }}
+      # .wp-env.override.json is deep-merged over .wp-env.json. Two things go in
+      # it, so they are written together rather than by competing steps that
+      # would overwrite each other's file: the PHP version under test, and the
+      # mapping for the prebuilt Pro plugin. provision-site.php activates Pro +
+      # its license later.
+      - name: Configure wp-env override (PHP version + Pro mapping)
         working-directory: tests/e2e
+        env:
+          PHP_VERSION: ${{ github.event.inputs.php_version || '7.4' }}
+          PRO_PATH: ${{ github.workspace }}/storegrowth-sales-booster-pro
+          HAS_PRO: ${{ needs.build.outputs.has-pro }}
         run: |
-          cat > .wp-env.override.json <<JSON
-          {
-            "mappings": {
-              "wp-content/plugins/storegrowth-sales-booster-pro": "${{ github.workspace }}/storegrowth-sales-booster-pro"
-            }
-          }
-          JSON
+          if [ "$HAS_PRO" = "true" ]; then
+            jq -n --arg php "$PHP_VERSION" --arg pro "$PRO_PATH" \
+              '{phpVersion: $php, mappings: {"wp-content/plugins/storegrowth-sales-booster-pro": $pro}}' \
+              > .wp-env.override.json
+          else
+            jq -n --arg php "$PHP_VERSION" '{phpVersion: $php}' > .wp-env.override.json
+          fi
+          cat .wp-env.override.json
 
       # ---- Boot WordPress + WooCommerce + this plugin via wp-env ----
       # .wp-env.json lives in tests/e2e, so wp-env runs from there.
@@ -260,6 +281,14 @@ jobs:
         run: |
           npm -g install @wordpress/env
           wp-env start
+
+      # Prove the site is actually on the requested PHP, so a run labelled
+      # "PHP 7.4" can't quietly have tested 8.2.
+      - name: Report the site's PHP version
+        working-directory: tests/e2e
+        run: |
+          wp-env run cli wp eval 'echo PHP_VERSION, PHP_EOL;'
+          echo "PHP under test: $(wp-env run cli wp eval 'echo PHP_VERSION;' 2>/dev/null | tr -d '\r')" >> "$GITHUB_STEP_SUMMARY"
 
       # Storefront is a classic theme; the storefront specs assert against its
       # classic WooCommerce markup (.summary / .entry-summary / ul.products).

--- a/includes/DependencyManagement/BaseServiceProvider.php
+++ b/includes/DependencyManagement/BaseServiceProvider.php
@@ -32,7 +32,7 @@ abstract class BaseServiceProvider extends AbstractServiceProvider {
      * @return bool True if the service provider can provide the service, false otherwise.
      */
     public function provides( string $alias ): bool {
-        static $implements = array();
+        $implements = array();
 
         foreach ( $this->services as $class ) {
             if ( ! class_exists( $class ) ) {

--- a/includes/DependencyManagement/Providers/CommonServiceProvider.php
+++ b/includes/DependencyManagement/Providers/CommonServiceProvider.php
@@ -30,19 +30,50 @@ class CommonServiceProvider extends BootableServiceProvider {
 	];
 
 	/**
+	 * Whether the services have already been registered.
+	 *
+	 * @since SPSG_VERSION
+	 *
+	 * @var bool
+	 */
+	protected $is_registered = false;
+
+	/**
 	 * Boot the provider.
+	 *
+	 * Registration cannot be left to the container's lazy resolution: it only falls
+	 * through to a service provider when no definition already carries the requested
+	 * tag, and the module providers register their own `WP_REST_Controller` /
+	 * `HookRegistry` definitions first, so this provider would never be asked.
+	 *
+	 * It also cannot run right now: `ProductController` extends a WooCommerce class,
+	 * and the tags are derived from the parent chain, so WooCommerce must have
+	 * declared its classes first.
 	 *
 	 * @inheritDoc
 	 *
 	 * @return void
 	 */
 	public function boot(): void {
+		if ( did_action( 'woocommerce_loaded' ) ) {
+			$this->register();
+
+			return;
+		}
+
+		add_action( 'woocommerce_loaded', [ $this, 'register' ], 0 );
 	}
 
 	/**
 	 * Register the classes.
 	 */
 	public function register(): void {
+		if ( $this->is_registered ) {
+			return;
+		}
+
+		$this->is_registered = true;
+
 		foreach ( $this->services as $service ) {
 			$this->share_with_implements_tags( $service );
 		}


### PR DESCRIPTION
## Problem

`GET /wp-json/sales-booster/v1/products` returns `rest_no_route` (404) on PHP 7.4 and 8.0. The admin settings UI's product picker is therefore empty on those sites. The `Upgrader` migration and notice routes are dead for the same reason.

The route is fine on PHP 8.1+, which is why CI never caught it — `.wp-env.json` and `e2e.yml` both pin PHP 8.2, and `tests/api/products.api.spec.ts` passes there.

## Root cause

`CommonServiceProvider` is the only provider that registers `ProductController` and `Upgrader`, and its `register()` was never called.

League resolves service providers lazily. `Container::resolve()` (`lib/packages/League/Container/Container.php:172`) checks `definitions->hasTag($id)` at line 179 **before** it consults `providers->provides($id)` at line 191:

```php
if ($this->definitions->hasTag($id)) {
    return $this->definitions->resolveTagged($id);   // <- short-circuits here
}

if ($this->providers->provides($id)) {
    $this->providers->register($id);                 // <- never reached
    ...
}
```

The module `BootstrapServiceProvider`s register eagerly when their module boots, and tag their own classes `WP_REST_Controller` / `HookRegistry`. By the time `Bootstrap::register_rest_routes()` / `register_hooks()` resolve either tag, a definition already carries it, so the provider branch is unreachable and `CommonServiceProvider` is never asked.

### Why PHP 8.1+ hid it

`BaseServiceProvider::provides()` used a `static` local:

```php
public function provides( string $alias ): bool {
    static $implements = array();
```

PHP 8.1 changed static variables in inherited methods to be **shared with the parent scope**; on 8.0 and below each subclass gets its own copy. So on 8.1+ the interfaces collected by one provider leak into every other provider's `provides()`, some provider ends up claiming an alias on `CommonServiceProvider`'s behalf, and it gets registered by accident. No leak on 7.4/8.0 → no registration → 404.

## Fix

- **`BaseServiceProvider.php`** — drop the `static` so `provides()` answers only for its own services. Behaviour is now identical on every supported PHP version instead of depending on 8.1 semantics.
- **`CommonServiceProvider.php`** — register eagerly on `woocommerce_loaded` rather than relying on lazy resolution. It cannot register any earlier: `ProductController` extends `WC_REST_Products_Controller` and the tags are derived from the parent chain (`class_parents()` + `isAbstract()`), so WooCommerce must have declared its classes first. Guarded with `did_action()` for the case where the provider is added after WC has booted, and with an `$is_registered` flag so a later lazy `register()` cannot double-add.

## Verification (PHP 7.4.33)

Before — 7 routes:

```
/sales-booster/v1
/sales-booster/v1/bogo/offers
/sales-booster/v1/bogo/offers/(?P<id>\d+)
...
```

After — 17 routes, including everything that was missing:

```
/sales-booster/v1/products
/sales-booster/v1/products/(?P<id>[\d]+)
/sales-booster/v1/products/batch
/sales-booster/v1/products/(?P<id>[\d]+)/related
/sales-booster/v1/products/suggested-products
/sales-booster/v1/products/(?P<id>[\d]+)/duplicate
/sales-booster/v1/migration/status
/sales-booster/v1/migration/upgrade
/sales-booster/v1/notices/admin
/sales-booster/v1/notices/dismiss
```

`curl` on the same endpoint goes `404 rest_no_route` → `401 woocommerce_rest_cannot_view` (route live, auth gate intact).

Container contents on 7.4 after the change: 10 modules, 32 `HookRegistry` implementations, 3 REST controllers.

### Checks run

- `php -l` on both changed files — clean.
- `vendor/bin/phpcs` — **no new violations**. `BaseServiceProvider.php` reports the same 91 errors / 3 warnings as `origin/develop` (all pre-existing space-indent); `CommonServiceProvider.php` is clean before and after.
- `vendor/bin/phpcs --standard=PHPCompatibilityWP --runtime-set testVersion 7.4-` over `includes/ modules/ integrations/ helpers/ storegrowth-sales-booster.php` — clean, exit 0.

### Migrations are not silently triggered

`Upgrader` coming back to life only wires `MigrationHooks` and the REST routes. Migrations still run on merchant confirmation via `/migration/upgrade`, and `maybe_stamp_fresh_install()` keeps new installs off the notice. No migration executes on page load.

## Follow-ups (not in this PR)

1. **E2E cannot catch this class of bug.** `.wp-env.json` and `.github/workflows/e2e.yml` pin PHP 8.2 — the version where the leak masked the failure. Worth adding 7.4 to the matrix, since `composer.json` declares `"php": ">=7.4"` and the plugin header says `Requires PHP: 7.4`.
2. **Vendor isolation on `/sales-booster/v1/products` depends on the BOGO module being active.** The only thing scoping the query to the current vendor is the `spsg_product_query_args` filter, added solely in `integrations/includes/Dokan/Dashboard/Bogo.php:40`, and that class is instantiated only when BOGO is active (`Dashboard.php:41`). Measured on a Dokan install: with BOGO active, seller 2 sees their own 12 products; with BOGO deactivated, the same seller sees 32 products across 7 authors. This is pre-existing and already live on every PHP 8.1+ site — this PR just makes 7.4/8.0 behave the same — but the scoping belongs in `ProductController` itself, not in a module integration.
