### PR TITLE
fix: reject malformed settings payloads instead of wiping the stored option

### DIFF
--- a/modules/countdown-timer/includes/Ajax.php
+++ b/modules/countdown-timer/includes/Ajax.php
@@ -42,8 +42,11 @@ class Ajax implements HookRegistry {
 			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
 		}
 
-		if ( ! isset( $_POST['form_data'] ) ) {
-			wp_send_json_error();
+		// array_map() over a non-array returns null on PHP 7.4 (and throws on
+		// PHP 8), so an unvalidated payload would overwrite the stored settings
+		// with nothing. Reject it instead.
+		if ( ! isset( $_POST['form_data'] ) || ! is_array( $_POST['form_data'] ) ) {
+			wp_send_json_error( __( 'Invalid settings payload.', 'storegrowth-sales-booster' ), 400 );
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via ` Helper::class, 'sanitize_form_fields'`.

--- a/modules/floating-notification-bar/assets/js/banner-bar-remove.js
+++ b/modules/floating-notification-bar/assets/js/banner-bar-remove.js
@@ -2,13 +2,13 @@
   // Check if spsgLocalizedData is defined and not empty
 
   if (typeof spsg_fnb_data !== "undefined") {
-    let banner_device_view = spsg_fnb_data.banner_device_view;
+    let banner_device_view = spsg_fnb_data.banner_device_view || [];
     let bar_position = spsg_fnb_data.bar_position;
     let banner_delay = spsg_fnb_data.banner_delay;
     let scroll_banner_delay = spsg_fnb_data.scroll_banner_delay;
     let banner_trigger = spsg_fnb_data.banner_trigger;
     let banner_height = spsg_fnb_data.banner_height;
-    let button_view = spsg_fnb_data.button_view;
+    let button_view = spsg_fnb_data.button_view || [];
     let countdown_start_date = spsg_fnb_data.countdown_start_date;
     let countdown_end_date = spsg_fnb_data.countdown_end_date;
     let coupon_code = spsg_fnb_data?.cupon_code?.toUpperCase();
@@ -259,6 +259,6 @@
       }
     });
   } else {
-    console.lo("banner_device_view is undefined or empty.");
+    console.log("banner_device_view is undefined or empty.");
   }
 })(jQuery);

--- a/modules/floating-notification-bar/includes/Ajax.php
+++ b/modules/floating-notification-bar/includes/Ajax.php
@@ -41,9 +41,21 @@ class Ajax implements HookRegistry {
 			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
 		}
 
-		$form_data = isset( $_POST['form_data'] ) ? json_decode( wp_unslash( $_POST['form_data'] ), true ) : array(); 
+		// json_decode() takes a string. An array here decodes to null on PHP 7.4
+		// and throws on PHP 8, and a string that is valid JSON can still be
+		// missing the key. Every one of those used to fall through to an
+		// unconditional update_option() and wipe the stored settings, so the
+		// payload is validated before anything is written.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- JSON payload; decoded and validated below.
+		$raw_form_data = isset( $_POST['form_data'] ) && is_string( $_POST['form_data'] ) ? wp_unslash( $_POST['form_data'] ) : '';
 
-		$bar_data = isset( $form_data['shipping_bar_data'] ) ? $form_data['shipping_bar_data'] : array();
+		$form_data = json_decode( $raw_form_data, true );
+
+		if ( ! is_array( $form_data ) || ! isset( $form_data['shipping_bar_data'] ) || ! is_array( $form_data['shipping_bar_data'] ) ) {
+			wp_send_json_error( __( 'Invalid settings payload.', 'storegrowth-sales-booster' ), 400 );
+		}
+
+		$bar_data = $form_data['shipping_bar_data'];
 
 		$icon_validator = array(
 			'default_banner_icon_html',

--- a/modules/floating-notification-bar/includes/Helper.php
+++ b/modules/floating-notification-bar/includes/Helper.php
@@ -20,6 +20,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Helper {
 
 	/**
+	 * Get the default settings for this module.
+	 *
+	 * Mirrors the defaults used by the settings UI so that a site which has
+	 * never saved the module settings still gets usable values.
+	 *
+	 * @since SPSG_VERSION
+	 *
+	 * @return array
+	 */
+	public static function get_default_settings() {
+		return array(
+			'banner_device_view' => array( 'banner-show-desktop' ),
+			'button_view'        => array( 'button-desktop-enable' ),
+		);
+	}
+
+	/**
 	 * Get settings for this module.
 	 *
 	 * @since 1.0.2
@@ -27,7 +44,10 @@ class Helper {
 	 * @return array
 	 */
 	public static function get_settings() {
-		return \StorePulse\StoreGrowth\Helper::get_settings( 'spsg_floating_notification_bar_settings', array() );
+		$settings = \StorePulse\StoreGrowth\Helper::get_settings( 'spsg_floating_notification_bar_settings', array() );
+
+		// Only fills in keys that are absent, so an explicitly emptied setting is preserved.
+		return wp_parse_args( $settings, self::get_default_settings() );
 	}
 
 	/**

--- a/modules/fly-cart/includes/Ajax.php
+++ b/modules/fly-cart/includes/Ajax.php
@@ -45,8 +45,11 @@ class Ajax implements HookRegistry {
 			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
 		}
 
-		if ( ! isset( $_POST['form_data'] ) ) {
-			wp_send_json_error();
+		// array_map() over a non-array returns null on PHP 7.4 (and throws on
+		// PHP 8), so an unvalidated payload would overwrite the stored settings
+		// with nothing. Reject it instead.
+		if ( ! isset( $_POST['form_data'] ) || ! is_array( $_POST['form_data'] ) ) {
+			wp_send_json_error( __( 'Invalid settings payload.', 'storegrowth-sales-booster' ), 400 );
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via ` Helper::class, 'sanitize_form_fields'`.

--- a/modules/progressive-discount-banner/includes/Ajax.php
+++ b/modules/progressive-discount-banner/includes/Ajax.php
@@ -41,9 +41,21 @@ class Ajax implements HookRegistry {
 			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
 		}
 
-		$form_data = isset( $_POST['form_data'] ) ? json_decode( wp_unslash( $_POST['form_data'] ), true ) : array();
+		// json_decode() takes a string. An array here decodes to null on PHP 7.4
+		// and throws on PHP 8, and a string that is valid JSON can still be
+		// missing the key. Every one of those used to fall through to an
+		// unconditional update_option() and wipe the stored settings, so the
+		// payload is validated before anything is written.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- JSON payload; decoded and validated below.
+		$raw_form_data = isset( $_POST['form_data'] ) && is_string( $_POST['form_data'] ) ? wp_unslash( $_POST['form_data'] ) : '';
 
-		$bar_data = isset( $form_data['shipping_bar_data'] ) ? $form_data['shipping_bar_data'] : array();
+		$form_data = json_decode( $raw_form_data, true );
+
+		if ( ! is_array( $form_data ) || ! isset( $form_data['shipping_bar_data'] ) || ! is_array( $form_data['shipping_bar_data'] ) ) {
+			wp_send_json_error( __( 'Invalid settings payload.', 'storegrowth-sales-booster' ), 400 );
+		}
+
+		$bar_data = $form_data['shipping_bar_data'];
 
 		$icon_validator = array(
 			'default_banner_icon_html',

--- a/modules/quick-view/includes/Ajax.php
+++ b/modules/quick-view/includes/Ajax.php
@@ -44,8 +44,11 @@ class Ajax implements HookRegistry {
 			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
 		}
 
-		if ( ! isset( $_POST['form_data'] ) ) {
-			wp_send_json_error();
+		// array_map() over a non-array returns null on PHP 7.4 (and throws on
+		// PHP 8), so an unvalidated payload would overwrite the stored settings
+		// with nothing. Reject it instead.
+		if ( ! isset( $_POST['form_data'] ) || ! is_array( $_POST['form_data'] ) ) {
+			wp_send_json_error( __( 'Invalid settings payload.', 'storegrowth-sales-booster' ), 400 );
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via ` Helper::class, 'sanitize_form_fields'`.

--- a/modules/sales-pop/includes/Ajax.php
+++ b/modules/sales-pop/includes/Ajax.php
@@ -61,8 +61,21 @@ class Ajax implements HookRegistry {
 			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
 		}
 
-		$popup_data     = isset( $_POST['data'] ) ? json_decode( wp_unslash( $_POST['data'] ), true ) : array(); //phpcs:ignore
-		$popup_products = isset( $popup_data['popup_data'] ) ? $popup_data['popup_data'] : array();
+		// json_decode() takes a string. An array here decodes to null on PHP 7.4
+		// and throws on PHP 8, and a string that is valid JSON can still be
+		// missing the key. Every one of those used to fall through to an
+		// unconditional update_option() and wipe the stored popups, so the
+		// payload is validated before anything is written.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- JSON payload; decoded and validated below.
+		$raw_popup_data = isset( $_POST['data'] ) && is_string( $_POST['data'] ) ? wp_unslash( $_POST['data'] ) : '';
+
+		$popup_data = json_decode( $raw_popup_data, true );
+
+		if ( ! is_array( $popup_data ) || ! isset( $popup_data['popup_data'] ) || ! is_array( $popup_data['popup_data'] ) ) {
+			wp_send_json_error( __( 'Invalid settings payload.', 'storegrowth-sales-booster' ), 400 );
+		}
+
+		$popup_products = $popup_data['popup_data'];
 		$popup_products = $this->form_validation( $popup_products );
 		$popup_products = self::sanitize_popup_data( $popup_products );
 		update_option( 'spsg_popup_products', $popup_products );

--- a/modules/stock-bar/includes/Ajax.php
+++ b/modules/stock-bar/includes/Ajax.php
@@ -42,8 +42,11 @@ class Ajax implements HookRegistry {
 			wp_send_json_error( __( 'You are not allowed to perform this action.', 'storegrowth-sales-booster' ), 403 );
 		}
 
-		if ( ! isset( $_POST['form_data'] ) ) {
-			wp_send_json_error();
+		// array_map() over a non-array returns null on PHP 7.4 (and throws on
+		// PHP 8), so an unvalidated payload would overwrite the stored settings
+		// with nothing. Reject it instead.
+		if ( ! isset( $_POST['form_data'] ) || ! is_array( $_POST['form_data'] ) ) {
+			wp_send_json_error( __( 'Invalid settings payload.', 'storegrowth-sales-booster' ), 400 );
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitizing via ` Helper::class, 'sanitize_form_fields'`.

--- a/tests/e2e/tests/ui/settings-malformed-payload.spec.ts
+++ b/tests/e2e/tests/ui/settings-malformed-payload.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '../../fixtures/test';
+import { spsgAdminAjax, moduleAjax, getSpsgAdmin } from '../../helpers/ajax';
+import { MODULES } from '../../data/modules';
+
+// Regression guard for the settings-wipe reported on PR #550.
+//
+// Every module's save_settings() used to hand whatever arrived in the request
+// straight to update_option(): the json_decode() handlers decoded a non-string
+// (or a JSON string missing their key) to nothing, and the array_map() handlers
+// mapped over a non-array to null. Either way the stored settings were replaced
+// with an empty value and the response was still {"success":true} — options
+// carry no revision history, so the real configuration was gone.
+//
+// Each case below saves a known payload, fires a malformed one, and asserts the
+// saved payload is still readable afterwards.
+
+type Malformed = Record<string, unknown>;
+
+async function saveViaAjax(page: any, action: string, fields: Record<string, unknown>) {
+  const res = await moduleAjax(page, action, fields);
+  expect(res.status, `${action} should answer`).toBe(200);
+  return res;
+}
+
+// moduleAjax() flattens objects into PHP-style form keys, so passing a string
+// sends a string and passing an object sends an array — exactly the two shapes
+// the handlers used to mishandle.
+test.describe('Admin · settings survive a malformed payload', { tag: '@ui' }, () => {
+  // --- json_decode() handlers: expect `form_data` to be a JSON *string*. ------
+  const jsonHandlers = [
+    {
+      label: 'Floating Notification Bar',
+      moduleId: MODULES.floatingBar.id,
+      save: 'spsg_floating_notification_bar_save_settings',
+      get: 'spsg_floating_notification_bar_get_settings',
+      key: 'shipping_bar_data',
+      field: 'form_data',
+    },
+    {
+      label: 'Progressive Discount Banner',
+      moduleId: MODULES.freeShipping.id,
+      save: 'spsg_pd_banner_save_settings',
+      get: 'spsg_pd_banner_get_settings',
+      key: 'shipping_bar_data',
+      field: 'form_data',
+    },
+  ];
+
+  for (const h of jsonHandlers) {
+    test(`${h.label} keeps its settings when form_data is malformed`, async ({ page }) => {
+      await spsgAdminAjax(page, 'update_module_status', { module_id: h.moduleId, status: 'true' });
+
+      const marker = `survives-${h.moduleId}`;
+      await saveViaAjax(page, h.save, {
+        [h.field]: JSON.stringify({ [h.key]: { e2e_marker: marker } }),
+      });
+
+      const malformed: Malformed[] = [
+        { [h.field]: { some_key: 'value' } }, // an array, not a JSON string
+        { [h.field]: '{}' }, // valid JSON, expected key missing
+        { [h.field]: '{' }, // not valid JSON at all
+        {}, // field absent entirely
+      ];
+
+      for (const payload of malformed) {
+        const res = await moduleAjax(page, h.save, payload);
+        expect(res.body?.success, `${h.save} must not report success for ${JSON.stringify(payload)}`).toBe(false);
+      }
+
+      const get = await moduleAjax(page, h.get);
+      expect(get.body?.success).toBe(true);
+      expect(get.body?.data, 'the saved settings must survive every malformed request').toMatchObject({
+        e2e_marker: marker,
+      });
+    });
+  }
+
+  // --- array_map() handlers: expect `form_data` to be an *array*. ------------
+  const arrayHandlers = [
+    { label: 'Countdown Timer', moduleId: MODULES.countdownTimer.id, save: 'spsg_countdown_timer_save_settings', get: 'spsg_countdown_timer_get_settings' },
+    { label: 'Stock Bar', moduleId: MODULES.stockBar.id, save: 'spsg_stock_bar_save_settings', get: 'spsg_stock_bar_get_settings' },
+    { label: 'Quick View', moduleId: MODULES.quickView.id, save: 'spsg_quick_view_save_settings', get: 'spsg_quick_view_get_settings' },
+    { label: 'Fly Cart', moduleId: MODULES.flyCart.id, save: 'spsg_fly_cart_save_settings', get: 'spsg_fly_cart_get_settings' },
+  ];
+
+  for (const h of arrayHandlers) {
+    test(`${h.label} keeps its settings when form_data is not an array`, async ({ page }) => {
+      await spsgAdminAjax(page, 'update_module_status', { module_id: h.moduleId, status: 'true' });
+
+      const marker = `survives-${h.moduleId}`;
+      await saveViaAjax(page, h.save, { form_data: { e2e_marker: marker } });
+
+      // A scalar `form_data` is what array_map() choked on.
+      const { ajax_url, nonce } = await getSpsgAdmin(page);
+      for (const scalar of ['not-an-array', '5']) {
+        const res = await page.request.post(ajax_url, {
+          form: { action: h.save, _ajax_nonce: nonce, form_data: scalar },
+        });
+        const body = res.status() === 200 ? JSON.parse((await res.text()) || 'null') : null;
+        expect(body?.success, `${h.save} must not report success for form_data="${scalar}"`).toBe(false);
+      }
+
+      const get = await moduleAjax(page, h.get);
+      expect(get.body?.success).toBe(true);
+      expect(get.body?.data, 'the saved settings must survive every malformed request').toMatchObject({
+        e2e_marker: marker,
+      });
+    });
+  }
+});


### PR DESCRIPTION
Fixes the settings-wipe reported on #550 (comment [5291916725](https://github.com/getdokan/storegrowth-sales-booster/pull/550#issuecomment-5291916725)). The report named two modules; the same defect is in **seven**.

## The defect

Every affected `save_settings()` handed whatever arrived in the request straight to `update_option()` with no check that it was the shape the handler expected. A malformed payload therefore replaced the module's entire configuration with an empty value **and answered `{"success":true}`**. WordPress options carry no revision history, so the real settings are unrecoverable.

Two variants:

**`json_decode()` handlers** — decode `$_POST['form_data']` / `$_POST['data']` without checking it is a string:

| input | PHP 7.4 | PHP 8 |
|---|---|---|
| an array | decodes to `null` | `TypeError` |
| `"{}"` (valid JSON, key missing) | decodes to `[]` | same |
| `"{"` (not valid JSON) | decodes to `null` | same |
| field absent | `array()` | same |

Each falls through to `$x = isset( $decoded['key'] ) ? … : array()` and that empty array gets written.

- `modules/floating-notification-bar/includes/Ajax.php:44`
- `modules/progressive-discount-banner/includes/Ajax.php:44`
- `modules/sales-pop/includes/Ajax.php:64` — not in the report, same shape

**`array_map()` handlers** — guard only `isset( $_POST['form_data'] )`. Mapping over a non-array returns `null` on PHP 7.4, so `null` is written; fly cart then `array_merge()`s that null and also produces null.

- `modules/stock-bar/includes/Ajax.php:50`
- `modules/countdown-timer/includes/Ajax.php:50`
- `modules/quick-view/includes/Ajax.php:52`
- `modules/fly-cart/includes/Ajax.php:53`

## The fix

Validate before writing; answer `wp_send_json_error( __( 'Invalid settings payload.', … ), 400 )` otherwise. The `json_decode()` sites also check `is_string()` on the raw input first, so the PHP 8 `TypeError` path is closed too.

## Verification — live PHP 7.4 site

Each `save_settings()` driven directly with a seeded option, `wp_die_ajax_handler` swapped for a throw so several cases run in one process.

**Before** (`git stash` of just the fix, same harness):

```
spsg_progressive_discount_banner_settings | form_data as array           | WIPED   | {"success":true,"data":[]}
spsg_progressive_discount_banner_settings | form_data valid JSON, no key | WIPED   | {"success":true,"data":[]}
spsg_progressive_discount_banner_settings | form_data malformed JSON     | WIPED   | {"success":true,"data":[]}
spsg_progressive_discount_banner_settings | form_data absent             | WIPED   | {"success":true,"data":[]}
spsg_stock_bar_settings                   | form_data as string          | WIPED   | {"success":true}
spsg_fly_cart_settings                    | form_data as string          | WIPED   | {"success":true}
spsg_popup_products                       | data as array                | WIPED   | {"success":true,…}
```

…and the same for floating bar, countdown timer, quick view.

**After:**

```
… | form_data as array           | INTACT | {"success":false,"data":"Invalid settings payload."}
… | form_data valid JSON, no key | INTACT | {"success":false,"data":"Invalid settings payload."}
… | form_data malformed JSON     | INTACT | {"success":false,"data":"Invalid settings payload."}
… | form_data absent             | INTACT | {"success":false,"data":"Invalid settings payload."}
… | VALID payload                | UPDATED| {"success":true,…}
```

All seven reject; valid payloads still save.

Note that `form_data absent` wiped too — the report's repro understates it, the pre-existing `wp_send_json_error()` guard in the `array_map()` handlers never fired for the `json_decode()` ones.

## Regression test

`tests/e2e/tests/ui/settings-malformed-payload.spec.ts` — saves a marker, fires each malformed shape, asserts the marker is still readable afterwards. Six modules covered.

Sales pop is fixed but not covered: it uses a different nonce (`spsg_admin_ajax_nonce`) and POST key than the `moduleAjax` helper sends. Worth a follow-up if the helper grows a nonce override.

## Checks

- `php -l` on all seven — clean.
- `vendor/bin/phpcs` — the same **19 pre-existing** errors as `origin/develop` on the touched files. No new violations.
- `vendor/bin/phpcs --standard=PHPCompatibilityWP --runtime-set testVersion 7.4-` — clean.
- `npx tsc --noEmit` — the new spec is clean (one unrelated pre-existing error in `storefront-bogo.spec.ts:222`).

## Not fixed here

`direct-checkout`, `bogo` (both handlers) and the Dokan integration already guard with `if ( isset( $data['…'] ) )` before writing, so they cannot destroy data. They do fall out of the function without sending any response at all on a bad payload, which the client reads as a failure with no message — worth tidying separately.

Related: #558 makes the E2E gate run on PHP 7.4, which is what lets the `array_map()` half of this actually fail in CI (on PHP 8 it is a fatal, not a wipe).
